### PR TITLE
Record evidence for semantic click locators

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -263,6 +263,18 @@ code_json="$(run_json diagnostics-code code --session "$SESSION_NAME" --file ./s
 assert_json "$code_json" "diagnostics fixture ready" \
   "data.ok === true && data.data.result === 'ready'"
 
+log "semantic click evidence"
+semantic_target_json="$(run_json semantic-target code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const button = document.createElement('button'); button.type = 'button'; button.textContent = 'semantic smoke action'; button.addEventListener('click', () => console.log('semantic-click-smoke')); document.body.appendChild(button); }); return 'semantic-target-ready'; }")"
+assert_json "$semantic_target_json" "semantic click target installed" \
+  "data.ok === true && data.data.result === 'semantic-target-ready'"
+semantic_click_json="$(run_json semantic-click click --session "$SESSION_NAME" --text 'semantic smoke action')"
+assert_json "$semantic_click_json" "semantic click records action evidence" \
+  "data.ok === true && data.data.acted === true && data.page.url === '${BLANK_URL}' && data.data.target.text === 'semantic smoke action' && data.data.target.nth === 1 && data.data.diagnosticsDelta.consoleDelta >= 1 && typeof data.data.run.runId === 'string'"
+SEMANTIC_RUN_ID="$(json_field "$semantic_click_json" "data.data.run.runId")"
+semantic_show_json="$(run_json semantic-click-show diagnostics show --run "$SEMANTIC_RUN_ID" --command click --limit 1)"
+assert_json "$semantic_show_json" "semantic click run preserves locator target" \
+  "data.ok === true && data.data.events.length === 1 && data.data.events[0].target.text === 'semantic smoke action' && data.data.events[0].target.nth === 1"
+
 log "fire diagnostics"
 click_json="$(run_json click-fire click --session "$SESSION_NAME" --selector '#fire')"
 assert_json "$click_json" "click fire acted" \

--- a/skills/pwcli/references/command-reference.md
+++ b/skills/pwcli/references/command-reference.md
@@ -89,6 +89,8 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 
 定位：aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
 
+所有 click 定位方式都会记录 action evidence：`target`、`diagnosticsDelta`、`run`。需要追踪动作后信号时用 `diagnostics runs/show/grep` 查对应 run。
+
 ### `pw fill [parts...] --session <name>`
 
 - `--selector <selector>`

--- a/src/app/commands/click.ts
+++ b/src/app/commands/click.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { managedClick, managedRunCode } from "../../domain/interaction/service.js";
+import { managedClick } from "../../domain/interaction/service.js";
 import { printCommandResult } from "../output.js";
 import {
   addSessionOption,
@@ -35,44 +35,55 @@ export function registerClickCommand(program: Command): void {
         return;
       }
 
-      const nth = Math.max(1, options.nth ? Number(options.nth) : 1) - 1;
-      let source = "";
+      const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
       if (options.role) {
-        source = `async page => { await page.getByRole(${JSON.stringify(options.role)}, ${options.name ? `{ name: ${JSON.stringify(options.name)}, exact: true }` : "undefined"}).nth(${nth}).click(); return 'clicked'; }`;
+        printCommandResult(
+          "click",
+          await managedClick({
+            semantic: {
+              kind: "role",
+              role: options.role,
+              ...(options.name ? { name: options.name } : {}),
+              nth,
+            },
+            sessionName,
+          }),
+        );
       } else if (options.text) {
-        source = `async page => {
-          const text = ${JSON.stringify(options.text)};
-          const locator = page.getByText(text, { exact: true });
-          const count = await locator.count();
-          if (count === 0) {
-            const candidates = await page.getByText(text, { exact: false }).evaluateAll(nodes =>
-              nodes.slice(0, 8).map(node => (node.textContent || '').trim()).filter(Boolean)
-            ).catch(() => []);
-            throw new Error('CLICK_TEXT_NOT_FOUND: text=' + text + (candidates.length ? ' similar=' + JSON.stringify(candidates) : ''));
-          }
-          if (${nth} >= count) {
-            throw new Error('CLICK_TEXT_INDEX_OUT_OF_RANGE: text=' + text + ' count=' + count + ' nth=' + ${nth + 1});
-          }
-          await locator.nth(${nth}).click();
-          return JSON.stringify({ clicked: true, text, count, nth: ${nth + 1} });
-        }`;
+        printCommandResult(
+          "click",
+          await managedClick({
+            semantic: { kind: "text", text: options.text, nth },
+            sessionName,
+          }),
+        );
       } else if (options.label) {
-        source = `async page => { await page.getByLabel(${JSON.stringify(options.label)}, { exact: true }).nth(${nth}).click(); return 'clicked'; }`;
+        printCommandResult(
+          "click",
+          await managedClick({
+            semantic: { kind: "label", label: options.label, nth },
+            sessionName,
+          }),
+        );
       } else if (options.placeholder) {
-        source = `async page => { await page.getByPlaceholder(${JSON.stringify(options.placeholder)}, { exact: true }).nth(${nth}).click(); return 'clicked'; }`;
+        printCommandResult(
+          "click",
+          await managedClick({
+            semantic: { kind: "placeholder", placeholder: options.placeholder, nth },
+            sessionName,
+          }),
+        );
       } else if (options.testid) {
-        source = `async page => { await page.getByTestId(${JSON.stringify(options.testid)}).nth(${nth}).click(); return 'clicked'; }`;
+        printCommandResult(
+          "click",
+          await managedClick({
+            semantic: { kind: "testid", testid: options.testid, nth },
+            sessionName,
+          }),
+        );
       } else {
         throw new Error("click requires a ref or one semantic locator");
       }
-
-      printCommandResult(
-        "click",
-        await managedRunCode({
-          sessionName,
-          source,
-        }),
-      );
     } catch (error) {
       printSessionAwareCommandError("click", error, {
         code: "CLICK_FAILED",

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -8,6 +8,13 @@ import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics
 import { maybeRawOutput, normalizeRef } from "./shared.js";
 import { managedPageCurrent } from "./workspace.js";
 
+type SemanticClickTarget =
+  | { kind: "role"; role: string; name?: string; nth?: number }
+  | { kind: "text"; text: string; nth?: number }
+  | { kind: "label"; label: string; nth?: number }
+  | { kind: "placeholder"; placeholder: string; nth?: number }
+  | { kind: "testid"; testid: string; nth?: number };
+
 async function recordRun(
   command: string,
   sessionName: string | undefined,
@@ -29,14 +36,38 @@ async function recordRun(
 export async function managedClick(options: {
   ref?: string;
   selector?: string;
+  semantic?: SemanticClickTarget;
   button?: string;
   sessionName?: string;
 }) {
-  if (!options.ref && !options.selector) {
-    throw new Error("click requires a ref or selector");
+  if (!options.ref && !options.selector && !options.semantic) {
+    throw new Error("click requires a ref, selector, or semantic locator");
   }
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
+
+  if (options.semantic) {
+    const target = normalizeSemanticClickTarget(options.semantic);
+    const result = await managedRunCode({
+      sessionName: options.sessionName,
+      source: semanticClickSource(target, options.button),
+    });
+    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+    const run = await recordRun("click", options.sessionName, result.page, {
+      target,
+      diagnosticsDelta,
+    });
+    return {
+      session: result.session,
+      page: result.page,
+      data: {
+        target,
+        acted: true,
+        diagnosticsDelta,
+        run,
+      },
+    };
+  }
 
   if (options.selector) {
     const button = options.button ? JSON.stringify({ button: options.button }) : "undefined";
@@ -101,6 +132,60 @@ export async function managedClick(options: {
       ...maybeRawOutput(result.text),
     },
   };
+}
+
+function normalizeSemanticClickTarget(target: SemanticClickTarget) {
+  return {
+    ...target,
+    nth: Math.max(1, Math.floor(Number(target.nth ?? 1))),
+  };
+}
+
+function semanticClickSource(
+  target: ReturnType<typeof normalizeSemanticClickTarget>,
+  button?: string,
+) {
+  const clickOptions = button ? JSON.stringify({ button }) : "undefined";
+  const nthIndex = target.nth - 1;
+  const targetJson = JSON.stringify(target);
+  const locatorExpression =
+    target.kind === "role"
+      ? `page.getByRole(${JSON.stringify(target.role)}, ${
+          target.name ? `{ name: ${JSON.stringify(target.name)}, exact: true }` : "undefined"
+        })`
+      : target.kind === "text"
+        ? `page.getByText(${JSON.stringify(target.text)}, { exact: true })`
+        : target.kind === "label"
+          ? `page.getByLabel(${JSON.stringify(target.label)}, { exact: true })`
+          : target.kind === "placeholder"
+            ? `page.getByPlaceholder(${JSON.stringify(target.placeholder)}, { exact: true })`
+            : `page.getByTestId(${JSON.stringify(target.testid)})`;
+
+  return `async page => {
+    const target = ${targetJson};
+    const locator = ${locatorExpression};
+    const count = await locator.count();
+    if (count === 0) {
+      let candidates = [];
+      if (target.kind === 'text') {
+        candidates = await page.getByText(target.text, { exact: false }).evaluateAll(nodes =>
+          nodes.slice(0, 8).map(node => (node.textContent || '').trim()).filter(Boolean)
+        ).catch(() => []);
+      }
+      throw new Error(
+        'CLICK_SEMANTIC_NOT_FOUND:' +
+          JSON.stringify({ target, ...(candidates.length ? { candidates } : {}) })
+      );
+    }
+    if (${nthIndex} >= count) {
+      throw new Error(
+        'CLICK_SEMANTIC_INDEX_OUT_OF_RANGE:' +
+          JSON.stringify({ target, count, nth: ${target.nth} })
+      );
+    }
+    await locator.nth(${nthIndex}).click(${clickOptions});
+    return JSON.stringify({ clicked: true, target, count, nth: ${target.nth} });
+  }`;
 }
 
 export async function managedFill(options: {


### PR DESCRIPTION
## Summary
- route semantic click locators through the action evidence path
- record `target`, `diagnosticsDelta`, and `run` for `click --text/--role/--label/--placeholder/--testid`
- add smoke coverage and update the click command reference

Fixes #22.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43180 pnpm smoke`
- `git diff --check`
@codex