### PR TITLE
Fix batch results compatibility

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -246,7 +246,7 @@ if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" batch --se
 fi
 batch_json="$batch_out"
 assert_json "$batch_json" "batch completed" \
-  "data.ok === true && data.data.completed === true && data.data.results === undefined"
+  "data.ok === true && data.data.completed === true && Array.isArray(data.data.results) && data.data.results.length === 2 && data.data.results.every(item => item.ok === true)"
 assert_json "$batch_json" "batch summary reflects successful execution" \
   "data.ok === true && data.data.summary.stepCount === 2 && data.data.summary.successCount === 2 && data.data.summary.failedCount === 0 && data.data.summary.firstFailedStep === null"
 
@@ -258,7 +258,7 @@ if ! printf '[ [\"session\",\"list\"] ]' | "${CLI[@]}" --output json batch --ses
 fi
 batch_fail_json="$batch_fail_out"
 assert_json "$batch_fail_json" "batch failed step exposes summary and reason code" \
-  "data.ok === true && data.data.summary.stepCount === 1 && data.data.summary.successCount === 0 && data.data.summary.failedCount === 1 && data.data.summary.firstFailedStep === 1 && data.data.summary.firstFailedCommand === 'session' && data.data.summary.failedSteps.length === 1 && data.data.summary.failedSteps[0].step === 1 && data.data.summary.failedSteps[0].command === 'session' && data.data.results === undefined"
+  "data.ok === true && data.data.summary.stepCount === 1 && data.data.summary.successCount === 0 && data.data.summary.failedCount === 1 && data.data.summary.firstFailedStep === 1 && data.data.summary.firstFailedCommand === 'session' && data.data.summary.failedSteps.length === 1 && data.data.summary.failedSteps[0].step === 1 && data.data.summary.failedSteps[0].command === 'session' && Array.isArray(data.data.results) && data.data.results.length === 1 && data.data.results[0].ok === false"
 
 batch_verbose_out="${TMP_DIR}/batch-verbose.json"
 if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json --include-results >"$batch_verbose_out"; then
@@ -269,6 +269,16 @@ fi
 batch_verbose_json="$batch_verbose_out"
 assert_json "$batch_verbose_json" "batch include-results keeps full step outputs when requested" \
   "data.ok === true && Array.isArray(data.data.results) && data.data.results.length === 2 && data.data.results.every(item => item.ok === true)"
+
+batch_summary_only_out="${TMP_DIR}/batch-summary-only.json"
+if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json --summary-only >"$batch_summary_only_out"; then
+  log "command failed: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json --summary-only"
+  cat "$batch_summary_only_out" >&2 || true
+  exit 1
+fi
+batch_summary_only_json="$batch_summary_only_out"
+assert_json "$batch_summary_only_json" "batch summary-only omits full step outputs when requested" \
+  "data.ok === true && data.data.completed === true && data.data.summary.stepCount === 2 && data.data.results === undefined"
 
 log "bootstrap apply"
 bootstrap_json="$(run_json bootstrap-apply bootstrap apply --session "$SESSION_NAME" --init-script ./scripts/manual/bootstrap-fixture.js --headers-file "$HEADERS_FILE")"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -478,7 +478,7 @@ pw batch --session bug-a --file ./steps.json
 - 要 JSON 输出：`pw --output json batch --session bug-a --stdin-json`。
 - `batch` 适合单 session 串行动作，不适合 lifecycle/auth/environment/dialog recovery。
 - batch `click` 只支持 ref 或 `--selector`，不支持 `--text`/`--role`/`--label` 等语义定位；需要语义定位时拆出单命令。
-- 默认输出只给 `data.summary`（减少重复信息和 token 消耗）；排障时再加 `--include-results` 看 step 明细。
+- 默认输出包含 `data.results` 和 `data.summary`；只需要轻量汇总时加 `--summary-only`。
 - 超出稳定子集时，直接跑单命令或用 `pw code`。
 
 ## 12. 标准任务模板

--- a/skills/pwcli/references/command-reference-advanced.md
+++ b/skills/pwcli/references/command-reference-advanced.md
@@ -78,7 +78,7 @@
 
 输入：`--stdin-json` / `--json`（别名）/ `--file <path>`，格式均为 `string[][]`。
 
-选项：`--continue-on-error`、`--include-results`
+选项：`--continue-on-error`、`--include-results`、`--summary-only`
 
 稳定 argv 子集：
 
@@ -98,8 +98,9 @@
 - `batch --stdin-json` 表示 stdin steps 是 JSON，不表示输出 JSON；要 JSON 输出加 `pw --output json batch ...`
 - `session` / `auth` / `environment` / `dialog` / diagnostics query 不属于稳定子集
 - `data.analysis.warnings` 是串行依赖提示
-- 默认只返回 `data.summary`（避免结果重复和 token 噪声）；失败信息看 `firstFailure*` 和 `failedSteps`
-- 需要完整 step 明细时再加 `--include-results`
+- 默认返回 `data.results` 和 `data.summary`，兼容既有自动化消费
+- 只需要汇总时加 `--summary-only`；失败信息看 `firstFailure*` 和 `failedSteps`
+- `--include-results` 保持可用，适合显式声明脚本依赖 step 明细
 
 ## Environment
 

--- a/src/app/batch/run-batch.ts
+++ b/src/app/batch/run-batch.ts
@@ -101,18 +101,19 @@ function unsupportedBatchStepMessage(tokens: string[]) {
   return `unsupported batch step '${command}'`;
 }
 
-function validateBatchPlan(commands: string[][]) {
-  for (const tokens of commands) {
+function findInvalidBatchStep(commands: string[][]) {
+  for (const [index, tokens] of commands.entries()) {
     const [command] = tokens;
     if (!command) {
-      throw new Error("batch step is empty");
+      return { index, tokens, message: "batch step is empty" };
     }
     if (
       !SUPPORTED_BATCH_TOP_LEVEL.includes(command as (typeof SUPPORTED_BATCH_TOP_LEVEL)[number])
     ) {
-      throw new Error(unsupportedBatchStepMessage(tokens));
+      return { index, tokens, message: unsupportedBatchStepMessage(tokens) };
     }
   }
+  return null;
 }
 
 function analyzeBatchPlan(commands: string[][], continueOnError?: boolean) {
@@ -793,12 +794,58 @@ export async function runBatch(options: {
   commands: string[][];
   continueOnError?: boolean;
   includeResults?: boolean;
+  summaryOnly?: boolean;
 }) {
   if (!options.commands.length) {
     throw new Error("batch requires at least one step");
   }
-  validateBatchPlan(options.commands);
   const analysis = analyzeBatchPlan(options.commands, options.continueOnError);
+  const invalidStep = findInvalidBatchStep(options.commands);
+
+  if (invalidStep) {
+    const reasonCode = extractReasonCode(invalidStep.message);
+    const suggestions = buildBatchStepSuggestions(invalidStep.message);
+    return {
+      completed: true,
+      analysis,
+      summary: {
+        stepCount: options.commands.length,
+        successCount: 0,
+        failedCount: 1,
+        firstFailedStep: invalidStep.index + 1,
+        firstFailedCommand: invalidStep.tokens[0] ?? null,
+        firstFailureReasonCode: reasonCode ?? null,
+        firstFailureMessage: invalidStep.message,
+        firstFailureSuggestions: suggestions ?? null,
+        failedSteps: [
+          {
+            step: invalidStep.index + 1,
+            command: invalidStep.tokens[0] ?? null,
+            reasonCode: reasonCode ?? null,
+          },
+        ],
+        continueOnError: Boolean(options.continueOnError),
+      },
+      ...(!options.summaryOnly
+        ? {
+            results: [
+              {
+                ok: false,
+                index: invalidStep.index,
+                argv: invalidStep.tokens,
+                step: formatBatchArgv(invalidStep.tokens),
+                error: {
+                  code: "BATCH_STEP_FAILED",
+                  message: invalidStep.message,
+                  ...(reasonCode ? { reasonCode } : {}),
+                  ...(suggestions ? { suggestions } : {}),
+                },
+              },
+            ],
+          }
+        : {}),
+    };
+  }
 
   const results = [];
   const failedSteps: Array<{
@@ -822,7 +869,7 @@ export async function runBatch(options: {
         step: formatBatchArgv(argv),
         ...(await executeBatchStep(argv, options.sessionName)),
       };
-      if (options.includeResults) {
+      if (!options.summaryOnly) {
         results.push(stepResult);
       }
       successCount += 1;
@@ -843,7 +890,7 @@ export async function runBatch(options: {
         command: argv[0] ?? null,
         reasonCode: reasonCode ?? null,
       });
-      if (options.includeResults) {
+      if (!options.summaryOnly) {
         results.push({
           ok: false,
           index,
@@ -879,6 +926,6 @@ export async function runBatch(options: {
       failedSteps,
       continueOnError: Boolean(options.continueOnError),
     },
-    ...(options.includeResults ? { results } : {}),
+    ...(!options.summaryOnly ? { results } : {}),
   };
 }

--- a/src/app/commands/batch.ts
+++ b/src/app/commands/batch.ts
@@ -31,7 +31,8 @@ export function registerBatchCommand(program: Command): void {
       .option("--stdin-json", "Read a JSON array of argv arrays from stdin")
       .option("--file <path>", "Read a JSON array of argv arrays from a file")
       .option("--continue-on-error", "Continue after a failed step")
-      .option("--include-results", "Include full step-by-step results in output"),
+      .option("--include-results", "Include full step-by-step results in output")
+      .option("--summary-only", "Omit full step-by-step results from output"),
   ).action(
     async (options: {
       session?: string;
@@ -40,9 +41,13 @@ export function registerBatchCommand(program: Command): void {
       file?: string;
       continueOnError?: boolean;
       includeResults?: boolean;
+      summaryOnly?: boolean;
     }) => {
       try {
         const sessionName = requireSessionName(options);
+        if (options.includeResults && options.summaryOnly) {
+          throw new Error("batch accepts either --include-results or --summary-only, not both");
+        }
         const readsStdin = Boolean(options.json || options.stdinJson);
         if (readsStdin && options.file) {
           throw new Error("batch accepts either --stdin-json/--json or --file, not both");
@@ -70,6 +75,7 @@ export function registerBatchCommand(program: Command): void {
             commands,
             continueOnError: options.continueOnError,
             includeResults: options.includeResults,
+            summaryOnly: options.summaryOnly,
           }),
         });
       } catch (error) {


### PR DESCRIPTION
## Summary
- Restore `batch` default output to include `data.results` for existing automation compatibility.
- Add explicit `--summary-only` for lightweight batch output.
- Preserve step-level summary/result output for invalid batch steps without executing the invalid plan.
- Sync pwcli skill docs and smoke coverage.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43183 pnpm smoke`
- `pnpm run test:dogfood:e2e`