### PR TITLE
Surface managed action errors

### DIFF
--- a/scripts/e2e/pwcli-dogfood-e2e.sh
+++ b/scripts/e2e/pwcli-dogfood-e2e.sh
@@ -148,6 +148,7 @@ log "login page inspection"
 snapshot_json="$(run_json login-snapshot snapshot --session "$SESSION_NAME")"
 assert_json "$snapshot_json" "login snapshot has title" \
   "data.ok === true && typeof data.data.snapshot === 'string' && data.data.snapshot.includes('pwcli dogfood login')"
+login_submit_ref="$(json_field "$snapshot_json" "data.data.snapshot.match(/Sign in[^\\n]*\\[ref=([^\\]]+)\\]/)?.[1]")"
 read_login_json="$(run_json login-read read-text --session "$SESSION_NAME" --max-chars 800)"
 assert_json "$read_login_json" "login read text sees remember me" \
   "data.ok === true && data.data.text.includes('Remember me')"
@@ -161,6 +162,14 @@ click_login_json="$(run_json login-click click --session "$SESSION_NAME" --selec
 assert_json "$click_login_json" "login clicked" "data.ok === true && data.data.acted === true"
 wait_projects_json="$(run_json wait-projects wait --session "$SESSION_NAME" --selector '#project-alpha')"
 assert_json "$wait_projects_json" "projects page visible" "data.ok === true && data.data.matched === true"
+stale_ref_out="${TMP_DIR}/stale-login-ref.json"
+if "${CLI[@]}" click --session "$SESSION_NAME" "$login_submit_ref" >"$stale_ref_out"; then
+  log "expected stale login ref to fail after navigation"
+  cat "$stale_ref_out" >&2 || true
+  exit 1
+fi
+assert_json "$stale_ref_out" "stale login ref surfaces refresh recovery" \
+  "data.ok === false && data.error.code === 'CLICK_FAILED' && data.error.message.includes('Ref ${login_submit_ref} not found in the current page snapshot') && data.error.suggestions.some(item => item.includes('snapshot -i'))"
 
 log "save auth state"
 state_save_json="$(run_json state-save state save "$STATE_FILE" --session "$SESSION_NAME")"

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -30,6 +30,22 @@ pw session create bug-a --open 'https://example.com'
 
 ## Modal blockage
 
+### Action failure with `Ref ... not found in the current page snapshot`
+
+Meaning:
+
+- the ref came from an older snapshot
+- the page navigated, re-rendered, switched tab, or otherwise changed after the ref was captured
+
+Recovery:
+
+```bash
+pw snapshot -i --session bug-a
+pw click <fresh-ref> --session bug-a
+```
+
+Do not retry the old ref after a page transition. Use a semantic locator such as `--role` or `--text` when the target must survive navigation or re-rendering.
+
 ### `MODAL_STATE_BLOCKED`
 
 Meaning:

--- a/src/app/commands/click.ts
+++ b/src/app/commands/click.ts
@@ -90,6 +90,7 @@ export function registerClickCommand(program: Command): void {
         message: "click failed",
         suggestions: [
           "Pass a valid aria ref from `pw snapshot`",
+          "If the page changed, refresh refs with `pw snapshot -i --session <name>`",
           "Or use one semantic locator: --selector/--role/--text/--label/--placeholder/--testid",
         ],
       });

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -2,7 +2,12 @@ import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { appendRunEvent, ensureRunDir } from "../../fs/run-artifacts.js";
 import { runManagedSessionCommand } from "../cli-client.js";
-import { parseDownloadEvent, parsePageSummary, stripQuotes } from "../output-parsers.js";
+import {
+  parseDownloadEvent,
+  parseErrorText,
+  parsePageSummary,
+  stripQuotes,
+} from "../output-parsers.js";
 import { managedRunCode } from "./code.js";
 import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics.js";
 import { maybeRawOutput, normalizeRef } from "./shared.js";
@@ -31,6 +36,13 @@ async function recordRun(
     ...details,
   });
   return run;
+}
+
+function throwIfManagedCommandError(text: string) {
+  const errorText = parseErrorText(text);
+  if (errorText) {
+    throw new Error(errorText);
+  }
 }
 
 export async function managedClick(options: {
@@ -111,6 +123,7 @@ export async function managedClick(options: {
       sessionName: options.sessionName,
     },
   );
+  throwIfManagedCommandError(result.text);
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("click", options.sessionName, parsePageSummary(result.text), {
@@ -235,6 +248,7 @@ export async function managedFill(options: {
       sessionName: options.sessionName,
     },
   );
+  throwIfManagedCommandError(result.text);
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("fill", options.sessionName, parsePageSummary(result.text), {
@@ -276,6 +290,7 @@ export async function managedType(options: {
         sessionName: options.sessionName,
       },
     );
+    throwIfManagedCommandError(result.text);
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
     const run = await recordRun("type", options.sessionName, parsePageSummary(result.text), {
       diagnosticsDelta,
@@ -332,6 +347,7 @@ export async function managedPress(key: string, options?: { sessionName?: string
       sessionName: options?.sessionName,
     },
   );
+  throwIfManagedCommandError(result.text);
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options?.sessionName, before);
   const run = await recordRun("press", options?.sessionName, parsePageSummary(result.text), {
@@ -369,6 +385,7 @@ export async function managedDialog(
       sessionName: options?.sessionName,
     },
   );
+  throwIfManagedCommandError(result.text);
 
   return {
     session: {


### PR DESCRIPTION
## Summary
- Parse managed-session `### Error` output before marking direct action commands as successful.
- Prevent stale snapshot refs from returning `acted: true` when Playwright reports the ref is missing from the current snapshot.
- Add dogfood e2e coverage for reusing a login-page ref after navigation.
- Document the stale ref recovery path in `failure-recovery.md`.

Refs #21.

## Verification
- Red: `PWCLI_DOGFOOD_PORT=43292 pnpm build && PWCLI_DOGFOOD_PORT=43292 bash scripts/e2e/pwcli-dogfood-e2e.sh` failed because stale `click e17` returned `ok: true`.
- Green: `PWCLI_DOGFOOD_PORT=43292 pnpm build && PWCLI_DOGFOOD_PORT=43292 bash scripts/e2e/pwcli-dogfood-e2e.sh`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43293 pnpm smoke`
- `git diff --check`