### PR TITLE
Stabilize managed action failure contract

### DIFF
--- a/scripts/e2e/pwcli-dogfood-e2e.sh
+++ b/scripts/e2e/pwcli-dogfood-e2e.sh
@@ -168,8 +168,8 @@ if "${CLI[@]}" click --session "$SESSION_NAME" "$login_submit_ref" >"$stale_ref_
   cat "$stale_ref_out" >&2 || true
   exit 1
 fi
-assert_json "$stale_ref_out" "stale login ref surfaces refresh recovery" \
-  "data.ok === false && data.error.code === 'CLICK_FAILED' && data.error.message.includes('Ref ${login_submit_ref} not found in the current page snapshot') && data.error.suggestions.some(item => item.includes('snapshot -i'))"
+assert_json "$stale_ref_out" "stale login ref surfaces structured recovery" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === true && data.error.message.includes('Ref ${login_submit_ref} not found in the current page snapshot') && data.error.suggestions.some(item => item.includes('snapshot -i')) && data.error.details.ref === '${login_submit_ref}'"
 
 log "save auth state"
 state_save_json="$(run_json state-save state save "$STATE_FILE" --session "$SESSION_NAME")"

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -30,7 +30,7 @@ pw session create bug-a --open 'https://example.com'
 
 ## Modal blockage
 
-### Action failure with `Ref ... not found in the current page snapshot`
+### `REF_STALE`
 
 Meaning:
 
@@ -45,6 +45,32 @@ pw click <fresh-ref> --session bug-a
 ```
 
 Do not retry the old ref after a page transition. Use a semantic locator such as `--role` or `--text` when the target must survive navigation or re-rendering.
+
+Typical output:
+
+```text
+ERROR REF_STALE
+Ref e17 not found in the current page snapshot
+Try:
+- Refresh refs with `pw snapshot -i --session bug-a`
+- Retry with a fresh ref from the new snapshot
+```
+
+`REF_STALE` means the old ref is no longer a safe write target. Do not retry the same ref.
+
+### Action target failures
+
+Stable codes:
+
+| Code | Meaning | First recovery |
+|---|---|---|
+| `ACTION_TARGET_NOT_FOUND` | target is not present in the current page state | `pw snapshot -i --session <name>` |
+| `ACTION_TARGET_AMBIGUOUS` | locator matched more than one target | use a narrower locator or `--nth` |
+| `ACTION_TARGET_INDEX_OUT_OF_RANGE` | requested `--nth` is greater than match count | inspect candidates and choose a valid index |
+| `ACTION_TIMEOUT_OR_NOT_ACTIONABLE` | Playwright could not act before timeout or target was not actionable | `pw wait --session <name> --selector <selector>` then retry |
+| `ACTION_BLOCKED_BY_MODAL` | reserved for browser dialog or modal state that blocks the action lane | `pw page dialogs --session <name>` then `pw dialog accept|dismiss` |
+
+These codes do not auto-heal selectors and do not pick among candidates. They tell the Agent which next command to run.
 
 ### `MODAL_STATE_BLOCKED`
 

--- a/src/app/commands/session-options.ts
+++ b/src/app/commands/session-options.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { isActionFailure } from "../../domain/interaction/action-failure.js";
 import { sessionRoutingError } from "../../domain/session/routing.js";
 import { MAX_SESSION_NAME_LENGTH } from "../../infra/playwright/cli-client.js";
 import { printCommandError } from "../output.js";
@@ -39,6 +40,17 @@ export function printSessionAwareCommandError(
   const routing = sessionRoutingError(message);
   if (routing) {
     printCommandError(command, routing);
+    return;
+  }
+
+  if (isActionFailure(error)) {
+    printCommandError(command, {
+      code: error.code,
+      message: error.message,
+      retryable: error.retryable,
+      suggestions: error.suggestions,
+      details: error.details,
+    });
     return;
   }
 

--- a/src/app/output.ts
+++ b/src/app/output.ts
@@ -138,14 +138,23 @@ function stringifyValue(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+function formatRunPointer(value: unknown): string | null {
+  const run = asRecord(value);
+  const runId = asString(run.runId);
+  const runDir = asString(run.runDir);
+  if (!runId && !runDir) {
+    return null;
+  }
+  return `run ${[runId ? `id=${runId}` : null, runDir ? `dir=${runDir}` : null]
+    .filter(Boolean)
+    .join(" ")}`;
+}
+
 function formatDiagnosticsDelta(value: unknown): string[] {
   const delta = asRecord(value);
   const consoleDelta = asNumber(delta.consoleDelta) ?? 0;
   const networkDelta = asNumber(delta.networkDelta) ?? 0;
   const pageErrorDelta = asNumber(delta.pageErrorDelta) ?? 0;
-  if (consoleDelta === 0 && networkDelta === 0 && pageErrorDelta === 0) {
-    return [];
-  }
   const lines = [
     `delta console=${consoleDelta} network=${networkDelta} pageError=${pageErrorDelta}`,
   ];
@@ -306,6 +315,10 @@ function formatAction(command: string, result: CommandResult): string {
   const lines = [`${command}${facts.length > 0 ? ` ${facts.join(" ")}` : " ok"}`];
   if (page) {
     lines.push(`page ${page}`);
+  }
+  const runPointer = formatRunPointer(result.data.run);
+  if (runPointer) {
+    lines.push(runPointer);
   }
   lines.push(...formatDiagnosticsDelta(result.data.diagnosticsDelta));
   return lines.join("\n");

--- a/src/domain/interaction/action-failure.ts
+++ b/src/domain/interaction/action-failure.ts
@@ -1,0 +1,35 @@
+export type ActionFailureCode =
+  | "REF_STALE"
+  | "ACTION_TARGET_NOT_FOUND"
+  | "ACTION_TARGET_AMBIGUOUS"
+  | "ACTION_TARGET_INDEX_OUT_OF_RANGE"
+  | "ACTION_TIMEOUT_OR_NOT_ACTIONABLE"
+  | "ACTION_BLOCKED_BY_MODAL";
+
+export type ActionFailureInput = {
+  code: ActionFailureCode;
+  message: string;
+  retryable?: boolean;
+  suggestions: string[];
+  details?: Record<string, unknown>;
+};
+
+export class ActionFailure extends Error {
+  readonly code: ActionFailureCode;
+  readonly retryable: boolean;
+  readonly suggestions: string[];
+  readonly details?: Record<string, unknown>;
+
+  constructor(input: ActionFailureInput) {
+    super(input.message);
+    this.name = "ActionFailure";
+    this.code = input.code;
+    this.retryable = Boolean(input.retryable);
+    this.suggestions = input.suggestions;
+    this.details = input.details;
+  }
+}
+
+export function isActionFailure(error: unknown): error is ActionFailure {
+  return error instanceof ActionFailure;
+}

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -7,7 +7,11 @@ type ManagedActionErrorContext = {
 };
 
 function isTargetNotFoundError(errorText: string) {
-  if (/No element matches selector/i.test(errorText) || /Unable to find/i.test(errorText)) {
+  if (
+    /No element matches selector/i.test(errorText) ||
+    /Unable to find/i.test(errorText) ||
+    /CLICK_SEMANTIC_NOT_FOUND/i.test(errorText)
+  ) {
     return true;
   }
 
@@ -24,6 +28,13 @@ export function throwIfManagedActionError(text: string, context: ManagedActionEr
     return;
   }
 
+  throwManagedActionErrorText(errorText, context);
+}
+
+export function throwManagedActionErrorText(
+  errorText: string,
+  context: ManagedActionErrorContext,
+) {
   const session = context.sessionName ?? null;
   const refMatch = errorText.match(
     /Ref\s+([A-Za-z0-9_-]+)\s+not found in the current page snapshot/i,
@@ -51,6 +62,20 @@ export function throwIfManagedActionError(text: string, context: ManagedActionEr
         "Narrow the locator so it resolves to one target",
         "Pass --nth when multiple matching targets are expected",
         `Inspect the current snapshot with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+      ],
+      details: { command: context.command, session },
+    });
+  }
+
+  if (/CLICK_SEMANTIC_INDEX_OUT_OF_RANGE|INDEX_OUT_OF_RANGE/i.test(errorText)) {
+    throw new ActionFailure({
+      code: "ACTION_TARGET_INDEX_OUT_OF_RANGE",
+      message: errorText,
+      retryable: true,
+      suggestions: [
+        "Pass an --nth value within the available target count",
+        `Inspect the current snapshot with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+        "Use a narrower selector or semantic locator when possible",
       ],
       details: { command: context.command, session },
     });

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -1,0 +1,75 @@
+import { ActionFailure } from "../../../domain/interaction/action-failure.js";
+import { parseErrorText } from "../output-parsers.js";
+
+type ManagedActionErrorContext = {
+  command: string;
+  sessionName?: string;
+};
+
+export function throwIfManagedActionError(text: string, context: ManagedActionErrorContext) {
+  const errorText = parseErrorText(text);
+  if (!errorText) {
+    return;
+  }
+
+  const session = context.sessionName ?? null;
+  const refMatch = errorText.match(
+    /Ref\s+([A-Za-z0-9_-]+)\s+not found in the current page snapshot/i,
+  );
+  if (refMatch) {
+    throw new ActionFailure({
+      code: "REF_STALE",
+      message: errorText,
+      retryable: true,
+      suggestions: [
+        `Refresh refs with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+        "Retry with a fresh ref from the new snapshot",
+        "Use a semantic locator such as --role or --text when the target must survive navigation or re-rendering",
+      ],
+      details: { command: context.command, ref: refMatch[1], session },
+    });
+  }
+
+  if (/strict mode violation/i.test(errorText)) {
+    throw new ActionFailure({
+      code: "ACTION_TARGET_AMBIGUOUS",
+      message: errorText,
+      retryable: true,
+      suggestions: [
+        "Narrow the locator so it resolves to one target",
+        "Pass --nth when multiple matching targets are expected",
+        `Inspect the current snapshot with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+      ],
+      details: { command: context.command, session },
+    });
+  }
+
+  if (
+    /timeout/i.test(errorText) ||
+    /not visible|not enabled|not stable|receives pointer events/i.test(errorText)
+  ) {
+    throw new ActionFailure({
+      code: "ACTION_TIMEOUT_OR_NOT_ACTIONABLE",
+      message: errorText,
+      retryable: true,
+      suggestions: [
+        "Wait for the target with a selector before retrying the action",
+        `Check page readiness with \`pw observe status --session ${context.sessionName ?? "<name>"}\``,
+        "Clear any dialog, modal, or overlay that may block the target",
+      ],
+      details: { command: context.command, session },
+    });
+  }
+
+  throw new ActionFailure({
+    code: "ACTION_TARGET_NOT_FOUND",
+    message: errorText,
+    retryable: true,
+    suggestions: [
+      `Refresh refs with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+      "Use an existing selector from the current page",
+      "Use a semantic locator such as --role or --text when possible",
+    ],
+    details: { command: context.command, session },
+  });
+}

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -31,10 +31,7 @@ export function throwIfManagedActionError(text: string, context: ManagedActionEr
   throwManagedActionErrorText(errorText, context);
 }
 
-export function throwManagedActionErrorText(
-  errorText: string,
-  context: ManagedActionErrorContext,
-) {
+export function throwManagedActionErrorText(errorText: string, context: ManagedActionErrorContext) {
   const session = context.sessionName ?? null;
   const refMatch = errorText.match(
     /Ref\s+([A-Za-z0-9_-]+)\s+not found in the current page snapshot/i,

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -6,6 +6,18 @@ type ManagedActionErrorContext = {
   sessionName?: string;
 };
 
+function isTargetNotFoundError(errorText: string) {
+  if (/No element matches selector/i.test(errorText) || /Unable to find/i.test(errorText)) {
+    return true;
+  }
+
+  if (/not found/i.test(errorText) && !/\b(dialog|modal)\b/i.test(errorText)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function throwIfManagedActionError(text: string, context: ManagedActionErrorContext) {
   const errorText = parseErrorText(text);
   if (!errorText) {
@@ -61,15 +73,19 @@ export function throwIfManagedActionError(text: string, context: ManagedActionEr
     });
   }
 
-  throw new ActionFailure({
-    code: "ACTION_TARGET_NOT_FOUND",
-    message: errorText,
-    retryable: true,
-    suggestions: [
-      `Refresh refs with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
-      "Use an existing selector from the current page",
-      "Use a semantic locator such as --role or --text when possible",
-    ],
-    details: { command: context.command, session },
-  });
+  if (isTargetNotFoundError(errorText)) {
+    throw new ActionFailure({
+      code: "ACTION_TARGET_NOT_FOUND",
+      message: errorText,
+      retryable: true,
+      suggestions: [
+        `Refresh refs with \`pw snapshot -i --session ${context.sessionName ?? "<name>"}\``,
+        "Use an existing selector from the current page",
+        "Use a semantic locator such as --role or --text when possible",
+      ],
+      details: { command: context.command, session },
+    });
+  }
+
+  throw new Error(errorText);
 }

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -3,7 +3,10 @@ import { dirname, join, resolve } from "node:path";
 import { appendRunEvent, ensureRunDir } from "../../fs/run-artifacts.js";
 import { runManagedSessionCommand } from "../cli-client.js";
 import { parseDownloadEvent, parsePageSummary, stripQuotes } from "../output-parsers.js";
-import { throwIfManagedActionError } from "./action-failure-classifier.js";
+import {
+  throwIfManagedActionError,
+  throwManagedActionErrorText,
+} from "./action-failure-classifier.js";
 import { managedRunCode } from "./code.js";
 import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics.js";
 import { maybeRawOutput, normalizeRef } from "./shared.js";
@@ -34,6 +37,24 @@ async function recordRun(
   return run;
 }
 
+async function managedActionRunCode(options: {
+  command: string;
+  sessionName?: string;
+  source: string;
+}) {
+  try {
+    return await managedRunCode({ sessionName: options.sessionName, source: options.source });
+  } catch (error) {
+    if (error instanceof Error) {
+      throwManagedActionErrorText(error.message, {
+        command: options.command,
+        sessionName: options.sessionName,
+      });
+    }
+    throw error;
+  }
+}
+
 export async function managedClick(options: {
   ref?: string;
   selector?: string;
@@ -49,7 +70,8 @@ export async function managedClick(options: {
 
   if (options.semantic) {
     const target = normalizeSemanticClickTarget(options.semantic);
-    const result = await managedRunCode({
+    const result = await managedActionRunCode({
+      command: "click",
       sessionName: options.sessionName,
       source: semanticClickSource(target, options.button),
     });
@@ -72,7 +94,8 @@ export async function managedClick(options: {
 
   if (options.selector) {
     const button = options.button ? JSON.stringify({ button: options.button }) : "undefined";
-    const result = await managedRunCode({
+    const result = await managedActionRunCode({
+      command: "click",
       sessionName: options.sessionName,
       source: `async page => {
         await page.locator(${JSON.stringify(options.selector)}).click(${button});
@@ -203,7 +226,8 @@ export async function managedFill(options: {
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await managedRunCode({
+    const result = await managedActionRunCode({
+      command: "fill",
       sessionName: options.sessionName,
       source: `async page => {
         await page.locator(${JSON.stringify(options.selector)}).fill(${JSON.stringify(options.value)});
@@ -306,7 +330,11 @@ export async function managedType(options: {
     ? `async page => { await page.locator(${JSON.stringify(`aria-ref=${target}`)}).type(${JSON.stringify(options.value)}); return 'typed'; }`
     : `async page => { await page.locator(${JSON.stringify(options.selector)}).type(${JSON.stringify(options.value)}); return 'typed'; }`;
 
-  const result = await managedRunCode({ source, sessionName: options.sessionName });
+  const result = await managedActionRunCode({
+    command: "type",
+    source,
+    sessionName: options.sessionName,
+  });
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("type", options.sessionName, result.page, {
     target: options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector },

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -2,12 +2,8 @@ import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { appendRunEvent, ensureRunDir } from "../../fs/run-artifacts.js";
 import { runManagedSessionCommand } from "../cli-client.js";
-import {
-  parseDownloadEvent,
-  parseErrorText,
-  parsePageSummary,
-  stripQuotes,
-} from "../output-parsers.js";
+import { parseDownloadEvent, parsePageSummary, stripQuotes } from "../output-parsers.js";
+import { throwIfManagedActionError } from "./action-failure-classifier.js";
 import { managedRunCode } from "./code.js";
 import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics.js";
 import { maybeRawOutput, normalizeRef } from "./shared.js";
@@ -36,13 +32,6 @@ async function recordRun(
     ...details,
   });
   return run;
-}
-
-function throwIfManagedCommandError(text: string) {
-  const errorText = parseErrorText(text);
-  if (errorText) {
-    throw new Error(errorText);
-  }
 }
 
 export async function managedClick(options: {
@@ -123,7 +112,7 @@ export async function managedClick(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedCommandError(result.text);
+  throwIfManagedActionError(result.text, { command: "click", sessionName: options.sessionName });
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("click", options.sessionName, parsePageSummary(result.text), {
@@ -248,7 +237,7 @@ export async function managedFill(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedCommandError(result.text);
+  throwIfManagedActionError(result.text, { command: "fill", sessionName: options.sessionName });
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("fill", options.sessionName, parsePageSummary(result.text), {
@@ -290,7 +279,7 @@ export async function managedType(options: {
         sessionName: options.sessionName,
       },
     );
-    throwIfManagedCommandError(result.text);
+    throwIfManagedActionError(result.text, { command: "type", sessionName: options.sessionName });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
     const run = await recordRun("type", options.sessionName, parsePageSummary(result.text), {
       diagnosticsDelta,
@@ -347,7 +336,7 @@ export async function managedPress(key: string, options?: { sessionName?: string
       sessionName: options?.sessionName,
     },
   );
-  throwIfManagedCommandError(result.text);
+  throwIfManagedActionError(result.text, { command: "press", sessionName: options?.sessionName });
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options?.sessionName, before);
   const run = await recordRun("press", options?.sessionName, parsePageSummary(result.text), {
@@ -385,7 +374,7 @@ export async function managedDialog(
       sessionName: options?.sessionName,
     },
   );
-  throwIfManagedCommandError(result.text);
+  throwIfManagedActionError(result.text, { command: "dialog", sessionName: options?.sessionName });
 
   return {
     session: {


### PR DESCRIPTION
## Summary
- Add typed action failure codes for direct managed action errors.
- Classify stale refs as `REF_STALE` instead of generic click failure.
- Classify verified action target failures across direct/ref and action-owned run-code paths while preserving unknown non-target errors.
- Show action run evidence and zero diagnostics delta in text output.
- Document concrete recovery paths for action failures.

Refs #21
Refs #41
Refs #37

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43293 pnpm smoke`
- `PWCLI_DOGFOOD_PORT=43292 bash scripts/e2e/pwcli-dogfood-e2e.sh`
- `git diff --check`