### PR TITLE
Support semantic fill and type

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -165,8 +165,18 @@ expectActionFailure(
   'ACTION_TARGET_NOT_FOUND',
 );
 expectActionFailure(
+  'semantic fill not found',
+  'FILL_SEMANTIC_NOT_FOUND:{"target":{"kind":"label","label":"missing semantic smoke field"}}',
+  'ACTION_TARGET_NOT_FOUND',
+);
+expectActionFailure(
   'semantic nth out of range',
   'CLICK_SEMANTIC_INDEX_OUT_OF_RANGE:{"target":{"kind":"text","text":"nth smoke action","nth":2},"count":1,"nth":2}',
+  'ACTION_TARGET_INDEX_OUT_OF_RANGE',
+);
+expectActionFailure(
+  'semantic type nth out of range',
+  'TYPE_SEMANTIC_INDEX_OUT_OF_RANGE:{"target":{"kind":"role","role":"textbox","nth":3},"count":1,"nth":3}',
   'ACTION_TARGET_INDEX_OUT_OF_RANGE',
 );
 expectActionFailure(
@@ -402,6 +412,29 @@ assert_json "$semantic_show_json" "semantic click run preserves locator target" 
 semantic_missing_json="$(run_fail_json semantic-missing click --session "$SESSION_NAME" --text 'missing semantic smoke action')"
 assert_json "$semantic_missing_json" "semantic missing target preserves action failure envelope" \
   "data.ok === false && data.error.code === 'ACTION_TARGET_NOT_FOUND' && data.error.retryable === true && data.error.message.includes('CLICK_SEMANTIC_NOT_FOUND') && data.error.suggestions.some(item => item.includes('snapshot -i')) && data.error.details.command === 'click'"
+
+log "semantic fill and type evidence"
+semantic_form_json="$(run_json semantic-form code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const root = document.createElement('form'); root.innerHTML = '<label>Email <input id=\"semantic-email\" data-testid=\"semantic-email\" placeholder=\"Email address\" /></label><label>Comment <textarea aria-label=\"Comment box\" placeholder=\"Comment body\"></textarea></label><input data-testid=\"semantic-search\" placeholder=\"Search terms\" />'; document.body.appendChild(root); }); return 'semantic-form-ready'; }")"
+assert_json "$semantic_form_json" "semantic form target installed" \
+  "data.ok === true && data.data.result === 'semantic-form-ready'"
+semantic_fill_label_json="$(run_json semantic-fill-label fill --session "$SESSION_NAME" --label Email 'agent@example.com')"
+assert_json "$semantic_fill_label_json" "semantic fill by label records action evidence" \
+  "data.ok === true && data.data.filled === true && data.data.target.label === 'Email' && data.data.target.nth === 1 && typeof data.data.run.runId === 'string'"
+semantic_fill_value_json="$(run_json semantic-fill-value code --session "$SESSION_NAME" "async page => page.locator('#semantic-email').inputValue()")"
+assert_json "$semantic_fill_value_json" "semantic fill by label changed value" \
+  "data.ok === true && data.data.result === 'agent@example.com'"
+semantic_fill_testid_json="$(run_json semantic-fill-testid fill --session "$SESSION_NAME" --testid semantic-search 'pwcli search')"
+assert_json "$semantic_fill_testid_json" "semantic fill by testid records target" \
+  "data.ok === true && data.data.filled === true && data.data.target.testid === 'semantic-search'"
+semantic_type_role_json="$(run_json semantic-type-role type --session "$SESSION_NAME" --role textbox --name 'Comment box' ' typed comment')"
+assert_json "$semantic_type_role_json" "semantic type by role records target" \
+  "data.ok === true && data.data.typed === true && data.data.target.role === 'textbox' && data.data.target.name === 'Comment box'"
+semantic_type_value_json="$(run_json semantic-type-value code --session "$SESSION_NAME" "async page => page.getByLabel('Comment box').inputValue()")"
+assert_json "$semantic_type_value_json" "semantic type by role changed value" \
+  "data.ok === true && data.data.result === ' typed comment'"
+semantic_fill_missing_json="$(run_fail_json semantic-fill-missing fill --session "$SESSION_NAME" --label 'Missing Email' 'x')"
+assert_json "$semantic_fill_missing_json" "semantic fill missing target preserves action failure envelope" \
+  "data.ok === false && data.error.code === 'ACTION_TARGET_NOT_FOUND' && data.error.retryable === true && data.error.details.command === 'fill'"
 
 log "fire diagnostics"
 click_json="$(run_json click-fire click --session "$SESSION_NAME" --selector '#fire')"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -178,6 +178,10 @@ pw click -s bug-a --selector 'button[type=submit]'
 pw fill -s bug-a --selector 'input[name=email]' 'user@example.com'
 pw click -s bug-a --role button --name '提交'
 pw click -s bug-a --text '继续'
+pw fill -s bug-a --label 'Email' 'user@example.com'
+pw fill -s bug-a --placeholder 'Search' 'keyword'
+pw fill -s bug-a --testid email-input 'user@example.com'
+pw type -s bug-a --role textbox --name 'Comment' 'hello'
 pw click e42 -s bug-a
 pw press Enter -s bug-a
 pw type -s bug-a --selector 'textarea' 'hello'

--- a/skills/pwcli/references/command-reference.md
+++ b/skills/pwcli/references/command-reference.md
@@ -93,11 +93,15 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 
 ### `pw fill [parts...] --session <name>`
 
-- `--selector <selector>`
+定位：aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
+
+有 `--selector` 或语义定位参数时，所有 `parts` 拼成填充值；否则第一个 part 是 ref，后续 parts 拼成填充值。
 
 ### `pw type [parts...] --session <name>`
 
-- `--selector <selector>`
+定位：focused element / aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
+
+无 `--selector` 和语义定位时：单个 part 输入到当前 focused element；多个 parts 时第一个 part 是 ref，后续 parts 拼成输入值。有 `--selector` 或语义定位参数时，所有 `parts` 拼成输入值。
 
 ### `pw press <key> --session <name>`
 

--- a/src/app/commands/fill.ts
+++ b/src/app/commands/fill.ts
@@ -7,18 +7,63 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+type FillOptions = {
+  session?: string;
+  selector?: string;
+  role?: string;
+  name?: string;
+  text?: string;
+  label?: string;
+  placeholder?: string;
+  testid?: string;
+  nth?: string;
+};
+
+function buildSemanticTarget(options: FillOptions) {
+  const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
+  if (options.role) {
+    return {
+      kind: "role" as const,
+      role: options.role,
+      ...(options.name ? { name: options.name } : {}),
+      nth,
+    };
+  }
+  if (options.text) {
+    return { kind: "text" as const, text: options.text, nth };
+  }
+  if (options.label) {
+    return { kind: "label" as const, label: options.label, nth };
+  }
+  if (options.placeholder) {
+    return { kind: "placeholder" as const, placeholder: options.placeholder, nth };
+  }
+  if (options.testid) {
+    return { kind: "testid" as const, testid: options.testid, nth };
+  }
+  return undefined;
+}
+
 export function registerFillCommand(program: Command): void {
   addSessionOption(
     program
       .command("fill [parts...]")
-      .description("Fill an input by aria ref or selector")
-      .option("--selector <selector>", "Selector target when no ref is provided"),
-  ).action(async (parts: string[], options: { session?: string; selector?: string }) => {
+      .description("Fill an input by aria ref, selector, or semantic locator")
+      .option("--selector <selector>", "Selector target when no ref is provided")
+      .option("--role <role>", "Role locator")
+      .option("--name <name>", "Accessible name for --role")
+      .option("--text <text>", "Exact text locator")
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index", "1"),
+  ).action(async (parts: string[], options: FillOptions) => {
     try {
       const sessionName = requireSessionName(options);
       const values = Array.isArray(parts) ? parts : [];
-      const ref = options.selector ? undefined : values[0];
-      const value = options.selector ? values.join(" ") : values.slice(1).join(" ");
+      const semantic = buildSemanticTarget(options);
+      const ref = options.selector || semantic ? undefined : values[0];
+      const value = options.selector || semantic ? values.join(" ") : values.slice(1).join(" ");
       if (!value) {
         throw new Error("fill requires a value");
       }
@@ -27,6 +72,7 @@ export function registerFillCommand(program: Command): void {
         await managedFill({
           ref,
           selector: options.selector,
+          semantic,
           value,
           sessionName,
         }),
@@ -35,7 +81,11 @@ export function registerFillCommand(program: Command): void {
       printSessionAwareCommandError("fill", error, {
         code: "FILL_FAILED",
         message: "fill failed",
-        suggestions: ["Use `pw fill --session bug-a e3 value` or selector mode"],
+        suggestions: [
+          "Use `pw fill --session bug-a e3 value` for a fresh ref",
+          "Use `pw fill --session bug-a --selector 'input[name=email]' value`",
+          "Use semantic locators such as `pw fill --session bug-a --label Email user@example.com`",
+        ],
       });
       process.exitCode = 1;
     }

--- a/src/app/commands/type.ts
+++ b/src/app/commands/type.ts
@@ -7,22 +7,69 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+type TypeOptions = {
+  session?: string;
+  selector?: string;
+  role?: string;
+  name?: string;
+  text?: string;
+  label?: string;
+  placeholder?: string;
+  testid?: string;
+  nth?: string;
+};
+
+function buildSemanticTarget(options: TypeOptions) {
+  const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
+  if (options.role) {
+    return {
+      kind: "role" as const,
+      role: options.role,
+      ...(options.name ? { name: options.name } : {}),
+      nth,
+    };
+  }
+  if (options.text) {
+    return { kind: "text" as const, text: options.text, nth };
+  }
+  if (options.label) {
+    return { kind: "label" as const, label: options.label, nth };
+  }
+  if (options.placeholder) {
+    return { kind: "placeholder" as const, placeholder: options.placeholder, nth };
+  }
+  if (options.testid) {
+    return { kind: "testid" as const, testid: options.testid, nth };
+  }
+  return undefined;
+}
+
 export function registerTypeCommand(program: Command): void {
   addSessionOption(
     program
       .command("type [parts...]")
-      .description("Type text into the focused element, aria ref, or selector")
-      .option("--selector <selector>", "Selector target when no ref is provided"),
-  ).action(async (parts: string[], options: { session?: string; selector?: string }) => {
+      .description("Type text into the focused element, aria ref, selector, or semantic locator")
+      .option("--selector <selector>", "Selector target when no ref is provided")
+      .option("--role <role>", "Role locator")
+      .option("--name <name>", "Accessible name for --role")
+      .option("--text <text>", "Exact text locator")
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index", "1"),
+  ).action(async (parts: string[], options: TypeOptions) => {
     try {
       const sessionName = requireSessionName(options);
       const values = Array.isArray(parts) ? parts : [];
-      const ref = options.selector ? undefined : values.length > 1 ? values[0] : undefined;
-      const value = options.selector
-        ? values.join(" ")
-        : values.length > 1
-          ? values.slice(1).join(" ")
-          : values[0];
+      const semantic = buildSemanticTarget(options);
+      const ref =
+        options.selector || semantic ? undefined : values.length > 1 ? values[0] : undefined;
+      const value =
+        options.selector || semantic
+          ? values.join(" ")
+          : values.length > 1
+            ? values.slice(1).join(" ")
+            : values[0];
       if (!value) {
         throw new Error("type requires a value");
       }
@@ -31,6 +78,7 @@ export function registerTypeCommand(program: Command): void {
         await managedType({
           ref,
           selector: options.selector,
+          semantic,
           value,
           sessionName,
         }),
@@ -39,7 +87,11 @@ export function registerTypeCommand(program: Command): void {
       printSessionAwareCommandError("type", error, {
         code: "TYPE_FAILED",
         message: "type failed",
-        suggestions: ["Use `pw type --session bug-a value` or `pw type --session bug-a e3 value`"],
+        suggestions: [
+          "Use `pw type --session bug-a value` for the focused element",
+          "Use `pw type --session bug-a e3 value` for a fresh ref",
+          "Use semantic locators such as `pw type --session bug-a --role textbox --name Comment hello`",
+        ],
       });
       process.exitCode = 1;
     }

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -10,7 +10,7 @@ function isTargetNotFoundError(errorText: string) {
   if (
     /No element matches selector/i.test(errorText) ||
     /Unable to find/i.test(errorText) ||
-    /CLICK_SEMANTIC_NOT_FOUND/i.test(errorText)
+    /(CLICK|FILL|TYPE)_SEMANTIC_NOT_FOUND/i.test(errorText)
   ) {
     return true;
   }
@@ -64,7 +64,7 @@ export function throwManagedActionErrorText(errorText: string, context: ManagedA
     });
   }
 
-  if (/CLICK_SEMANTIC_INDEX_OUT_OF_RANGE|INDEX_OUT_OF_RANGE/i.test(errorText)) {
+  if (/(CLICK|FILL|TYPE)_SEMANTIC_INDEX_OUT_OF_RANGE|INDEX_OUT_OF_RANGE/i.test(errorText)) {
     throw new ActionFailure({
       code: "ACTION_TARGET_INDEX_OUT_OF_RANGE",
       message: errorText,

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -12,7 +12,7 @@ import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics
 import { maybeRawOutput, normalizeRef } from "./shared.js";
 import { managedPageCurrent } from "./workspace.js";
 
-type SemanticClickTarget =
+type SemanticTarget =
   | { kind: "role"; role: string; name?: string; nth?: number }
   | { kind: "text"; text: string; nth?: number }
   | { kind: "label"; label: string; nth?: number }
@@ -58,7 +58,7 @@ async function managedActionRunCode(options: {
 export async function managedClick(options: {
   ref?: string;
   selector?: string;
-  semantic?: SemanticClickTarget;
+  semantic?: SemanticTarget;
   button?: string;
   sessionName?: string;
 }) {
@@ -69,7 +69,7 @@ export async function managedClick(options: {
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.semantic) {
-    const target = normalizeSemanticClickTarget(options.semantic);
+    const target = normalizeSemanticTarget(options.semantic);
     const result = await managedActionRunCode({
       command: "click",
       sessionName: options.sessionName,
@@ -159,32 +159,32 @@ export async function managedClick(options: {
   };
 }
 
-function normalizeSemanticClickTarget(target: SemanticClickTarget) {
+function normalizeSemanticTarget(target: SemanticTarget) {
   return {
     ...target,
     nth: Math.max(1, Math.floor(Number(target.nth ?? 1))),
   };
 }
 
-function semanticClickSource(
-  target: ReturnType<typeof normalizeSemanticClickTarget>,
-  button?: string,
-) {
+function semanticLocatorExpression(target: ReturnType<typeof normalizeSemanticTarget>) {
+  return target.kind === "role"
+    ? `page.getByRole(${JSON.stringify(target.role)}, ${
+        target.name ? `{ name: ${JSON.stringify(target.name)}, exact: true }` : "undefined"
+      })`
+    : target.kind === "text"
+      ? `page.getByText(${JSON.stringify(target.text)}, { exact: true })`
+      : target.kind === "label"
+        ? `page.getByLabel(${JSON.stringify(target.label)}, { exact: true })`
+        : target.kind === "placeholder"
+          ? `page.getByPlaceholder(${JSON.stringify(target.placeholder)}, { exact: true })`
+          : `page.getByTestId(${JSON.stringify(target.testid)})`;
+}
+
+function semanticClickSource(target: ReturnType<typeof normalizeSemanticTarget>, button?: string) {
   const clickOptions = button ? JSON.stringify({ button }) : "undefined";
   const nthIndex = target.nth - 1;
   const targetJson = JSON.stringify(target);
-  const locatorExpression =
-    target.kind === "role"
-      ? `page.getByRole(${JSON.stringify(target.role)}, ${
-          target.name ? `{ name: ${JSON.stringify(target.name)}, exact: true }` : "undefined"
-        })`
-      : target.kind === "text"
-        ? `page.getByText(${JSON.stringify(target.text)}, { exact: true })`
-        : target.kind === "label"
-          ? `page.getByLabel(${JSON.stringify(target.label)}, { exact: true })`
-          : target.kind === "placeholder"
-            ? `page.getByPlaceholder(${JSON.stringify(target.placeholder)}, { exact: true })`
-            : `page.getByTestId(${JSON.stringify(target.testid)})`;
+  const locatorExpression = semanticLocatorExpression(target);
 
   return `async page => {
     const target = ${targetJson};
@@ -213,17 +213,75 @@ function semanticClickSource(
   }`;
 }
 
+function semanticInputSource(
+  errorPrefix: "FILL" | "TYPE",
+  target: ReturnType<typeof normalizeSemanticTarget>,
+  action: "fill" | "type",
+  value: string,
+) {
+  const nthIndex = target.nth - 1;
+  const targetJson = JSON.stringify(target);
+  const locatorExpression = semanticLocatorExpression(target);
+
+  return `async page => {
+    const target = ${targetJson};
+    const locator = ${locatorExpression};
+    const count = await locator.count();
+    if (count === 0) {
+      throw new Error(
+        '${errorPrefix}_SEMANTIC_NOT_FOUND:' +
+          JSON.stringify({ target })
+      );
+    }
+    if (${nthIndex} >= count) {
+      throw new Error(
+        '${errorPrefix}_SEMANTIC_INDEX_OUT_OF_RANGE:' +
+          JSON.stringify({ target, count, nth: ${target.nth} })
+      );
+    }
+    await locator.nth(${nthIndex}).${action}(${JSON.stringify(value)});
+    return JSON.stringify({ ${action === "fill" ? "filled" : "typed"}: true });
+  }`;
+}
+
 export async function managedFill(options: {
   ref?: string;
   selector?: string;
+  semantic?: SemanticTarget;
   value: string;
   sessionName?: string;
 }) {
-  if (!options.ref && !options.selector) {
-    throw new Error("fill requires a ref or selector");
+  if (!options.ref && !options.selector && !options.semantic) {
+    throw new Error("fill requires a ref, selector, or semantic locator");
   }
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
+
+  if (options.semantic) {
+    const target = normalizeSemanticTarget(options.semantic);
+    const result = await managedActionRunCode({
+      command: "fill",
+      sessionName: options.sessionName,
+      source: semanticInputSource("FILL", target, "fill", options.value),
+    });
+
+    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+    const run = await recordRun("fill", options.sessionName, result.page, {
+      target,
+      diagnosticsDelta,
+    });
+    return {
+      session: result.session,
+      page: result.page,
+      data: {
+        target,
+        value: options.value,
+        filled: true,
+        diagnosticsDelta,
+        run,
+      },
+    };
+  }
 
   if (options.selector) {
     const result = await managedActionRunCode({
@@ -289,10 +347,37 @@ export async function managedFill(options: {
 export async function managedType(options: {
   ref?: string;
   selector?: string;
+  semantic?: SemanticTarget;
   value: string;
   sessionName?: string;
 }) {
   const before = await captureDiagnosticsBaseline(options.sessionName);
+
+  if (options.semantic) {
+    const target = normalizeSemanticTarget(options.semantic);
+    const result = await managedActionRunCode({
+      command: "type",
+      sessionName: options.sessionName,
+      source: semanticInputSource("TYPE", target, "type", options.value),
+    });
+
+    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+    const run = await recordRun("type", options.sessionName, result.page, {
+      target,
+      diagnosticsDelta,
+    });
+    return {
+      session: result.session,
+      page: result.page,
+      data: {
+        target,
+        value: options.value,
+        typed: true,
+        diagnosticsDelta,
+        run,
+      },
+    };
+  }
 
   if (!options.ref && !options.selector) {
     const result = await runManagedSessionCommand(


### PR DESCRIPTION
## Summary
- Add semantic locator support to fill and type.
- Reuse click-style target metadata, diagnostics delta, and run evidence.
- Update pwcli skill docs for Agent form workflows.

Refs #34

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43293 pnpm smoke`
- `git diff --check`