### PR TITLE
Summarize batch text output

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 CLI=(node dist/cli.js --output json)
+TEXT_CLI=(node dist/cli.js)
 PORT="${PWCLI_FIXTURE_PORT:-43179}"
 ORIGIN="http://127.0.0.1:${PORT}"
 BLANK_URL="${ORIGIN}/blank"
@@ -362,6 +363,40 @@ fi
 batch_summary_only_json="$batch_summary_only_out"
 assert_json "$batch_summary_only_json" "batch summary-only omits full step outputs when requested" \
   "data.ok === true && data.data.completed === true && data.data.summary.stepCount === 2 && data.data.results === undefined"
+
+batch_text_out="${TMP_DIR}/batch-text.txt"
+printf '[["observe","status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$batch_text_out"
+if ! grep -q 'batch completed=true steps=2 success=2 failed=0' "$batch_text_out"; then
+  log "batch text summary missing"
+  cat "$batch_text_out" >&2
+  exit 1
+fi
+if grep -q '"results"' "$batch_text_out"; then
+  log "batch default text should not dump nested results"
+  cat "$batch_text_out" >&2
+  exit 1
+fi
+
+batch_text_fail_out="${TMP_DIR}/batch-text-fail.txt"
+printf '[["session","list"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$batch_text_fail_out"
+if ! grep -q 'first failure step=1 command=session' "$batch_text_fail_out"; then
+  log "batch text first failure summary missing"
+  cat "$batch_text_fail_out" >&2
+  exit 1
+fi
+if ! grep -q 'batch does not support session lifecycle' "$batch_text_fail_out"; then
+  log "batch text failure message missing"
+  cat "$batch_text_fail_out" >&2
+  exit 1
+fi
+
+batch_text_verbose_out="${TMP_DIR}/batch-text-verbose.txt"
+printf '[["observe","status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --include-results >"$batch_text_verbose_out"
+if ! grep -q 'steps:' "$batch_text_verbose_out"; then
+  log "batch include-results text should show compact steps"
+  cat "$batch_text_verbose_out" >&2
+  exit 1
+fi
 
 log "bootstrap apply"
 bootstrap_json="$(run_json bootstrap-apply bootstrap apply --session "$SESSION_NAME" --init-script ./scripts/manual/bootstrap-fixture.js --headers-file "$HEADERS_FILE")"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -478,7 +478,10 @@ pw batch --session bug-a --file ./steps.json
 - 要 JSON 输出：`pw --output json batch --session bug-a --stdin-json`。
 - `batch` 适合单 session 串行动作，不适合 lifecycle/auth/environment/dialog recovery。
 - batch `click` 只支持 ref 或 `--selector`，不支持 `--text`/`--role`/`--label` 等语义定位；需要语义定位时拆出单命令。
-- 默认输出包含 `data.results` 和 `data.summary`；只需要轻量汇总时加 `--summary-only`。
+- 默认 text 输出是轻量摘要：step 数、成功/失败数、首个失败、warnings；不倾倒嵌套 `results`。
+- 脚本解析、字段断言、完整 envelope 消费必须加 `--output json`。
+- JSON envelope 保持 `data.summary` 和 `data.results`；只需要 JSON 汇总时加 `--summary-only`。
+- 默认 text 需要紧凑 step 明细时加 `--include-results`。
 - 超出稳定子集时，直接跑单命令或用 `pw code`。
 
 ## 12. 标准任务模板

--- a/skills/pwcli/references/command-reference-advanced.md
+++ b/skills/pwcli/references/command-reference-advanced.md
@@ -98,9 +98,10 @@
 - `batch --stdin-json` 表示 stdin steps 是 JSON，不表示输出 JSON；要 JSON 输出加 `pw --output json batch ...`
 - `session` / `auth` / `environment` / `dialog` / diagnostics query 不属于稳定子集
 - `data.analysis.warnings` 是串行依赖提示
-- 默认返回 `data.results` 和 `data.summary`，兼容既有自动化消费
-- 只需要汇总时加 `--summary-only`；失败信息看 `firstFailure*` 和 `failedSteps`
-- `--include-results` 保持可用，适合显式声明脚本依赖 step 明细
+- 默认 text 输出是轻量摘要，包含 step 数、成功/失败数、首个失败和 warnings，不倾倒嵌套 JSON
+- 脚本解析和字段断言必须加 `--output json`；JSON envelope 保持 `data.summary` 和 `data.results`
+- 只需要 JSON 汇总时加 `--summary-only`；失败信息看 `firstFailure*` 和 `failedSteps`
+- text 输出需要紧凑 step 明细时加 `--include-results`
 
 ## Environment
 

--- a/src/app/output.ts
+++ b/src/app/output.ts
@@ -324,7 +324,60 @@ function formatAction(command: string, result: CommandResult): string {
   return lines.join("\n");
 }
 
+function hasOutputFlag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
+function formatBatch(result: CommandResult): string {
+  const summary = asRecord(result.data.summary);
+  const analysis = asRecord(result.data.analysis);
+  const warnings = asArray(analysis.warnings).map(String);
+  const lines = [
+    `batch completed=${String(result.data.completed ?? true)} steps=${asNumber(summary.stepCount) ?? 0} success=${asNumber(summary.successCount) ?? 0} failed=${asNumber(summary.failedCount) ?? 0} continueOnError=${String(summary.continueOnError ?? false)}`,
+  ];
+  const firstFailedStep = asNumber(summary.firstFailedStep);
+  if (firstFailedStep !== null) {
+    lines.push(
+      `first failure step=${firstFailedStep} command=${asString(summary.firstFailedCommand) ?? "-"} reason=${asString(summary.firstFailureReasonCode) ?? "-"}`,
+    );
+    const message = asString(summary.firstFailureMessage);
+    if (message) {
+      lines.push(message);
+    }
+    const suggestions = asArray(summary.firstFailureSuggestions).map(String);
+    if (suggestions.length > 0) {
+      lines.push("Try:");
+      lines.push(...suggestions.map((item) => `- ${item}`));
+    }
+  }
+  if (warnings.length > 0) {
+    lines.push("warnings:");
+    lines.push(...warnings.map((item) => `- ${item}`));
+  }
+  if (hasOutputFlag("--include-results")) {
+    const results = asArray(result.data.results);
+    if (results.length > 0) {
+      lines.push("steps:");
+      for (const entry of results) {
+        const step = asRecord(entry);
+        const ok = Boolean(step.ok);
+        const error = asRecord(step.error);
+        const index = asNumber(step.index);
+        const command = asString(step.command) ?? asString(step.step) ?? "-";
+        const message = asString(error.message);
+        lines.push(
+          `${index !== null ? index + 1 : "?"}. ${ok ? "ok" : "failed"} ${command}${ok || !message ? "" : ` ${message}`}`.trim(),
+        );
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
 function formatCommandText(command: string, result: CommandResult): string {
+  if (command === "batch") {
+    return formatBatch(result);
+  }
   if (command === "read-text") {
     return formatReadText(result);
   }


### PR DESCRIPTION
## Summary
- Add compact default text output for batch runs.
- Keep JSON output contract unchanged.
- Document when Agents should use text summary, JSON, --include-results, and --summary-only.

Refs #37

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43294 pnpm smoke`
- `PWCLI_FIXTURE_PORT=43296 pnpm smoke`
- `git diff --check`

Note: one `PWCLI_FIXTURE_PORT=43295 pnpm smoke` rerun hit an existing route-only timeout after the batch text assertions had already passed; a clean rerun on 43296 passed end to end.