### PR TITLE
Expose Playwright session dashboard

### DIFF
--- a/docs/architecture/domain-status.md
+++ b/docs/architecture/domain-status.md
@@ -13,6 +13,7 @@
 ### 当前实现
 
 - `session create|attach|recreate|list|status|close`
+- `dashboard open` exposes Playwright-core's bundled session dashboard as a thin wrapper.
 - session 名硬限制：
   - 最长 16 字符
   - 只允许字母、数字、`-`、`_`
@@ -26,6 +27,7 @@
 
 - `session status` 只做快速状态检查；页面忙、弹窗阻塞、浏览器断连时可能拿不到完整页面信息，异常时用 `pw doctor --session <name>` 复查
 - `session attach --browser-url/--cdp` 只能接管当前机器上可连接的浏览器调试端口；连接失败时先确认浏览器是否用远程调试参数启动、端口是否可访问
+- `dashboard open` relies on an internal/hidden Playwright CLI surface and must fail as `DASHBOARD_UNAVAILABLE` if the entrypoint disappears.
 
 ### 后续扩展
 

--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -194,6 +194,11 @@ try {
 }
 NODE
 
+log "dashboard dry run"
+dashboard_json="$(run_json dashboard-dry-run dashboard open --dry-run)"
+assert_json "$dashboard_json" "dashboard entrypoint is available" \
+  "data.ok === true && data.data.available === true && data.data.launched === false && data.data.entrypoint.includes('playwright-core')"
+
 log "session create"
 create_json="$(run_json session-create session create "$SESSION_NAME" --open "$BLANK_URL")"
 assert_json "$create_json" "session create ok" \

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -83,6 +83,7 @@ pw diagnostics digest -s bug-a
 | 浏览器环境 | `environment` | 离线、地理位置、权限、时钟 |
 | 注入启动项 | `bootstrap` | init script、headers |
 | 串行编排 | `batch` | 单 session 稳定子集 |
+| 人类观察多 session | `dashboard open` | 需要观察/接管多个 Playwright managed sessions，不是 Agent 主执行链 |
 
 ## 2. Session
 
@@ -491,6 +492,15 @@ pw observe status -s explore-a
 pw read-text -s explore-a --max-chars 2000
 pw snapshot -i -s explore-a
 ```
+
+人类观察 / 接管：
+
+```bash
+pw dashboard open
+pw session list --with-page
+```
+
+Dashboard 只用于 human observation。不要把 `pw dashboard open` 放进常规 Agent 自动化循环；只有人需要检查多个 session、实时预览或接管状态时再打开。
 
 复现 bug：
 

--- a/skills/pwcli/references/command-reference-advanced.md
+++ b/skills/pwcli/references/command-reference-advanced.md
@@ -102,6 +102,14 @@
 - 只需要汇总时加 `--summary-only`；失败信息看 `firstFailure*` 和 `failedSteps`
 - `--include-results` 保持可用，适合显式声明脚本依赖 step 明细
 
+## Dashboard
+
+### `pw dashboard open`
+
+Opens Playwright-core's bundled session dashboard. This is a thin wrapper around Playwright's internal `playwright cli show` surface.
+
+Use for human observation or takeover. Do not use as a required Agent workflow step.
+
 ## Environment
 
 ### `pw environment offline on|off --session <name>`

--- a/src/app/commands/dashboard.ts
+++ b/src/app/commands/dashboard.ts
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Command } from "commander";
+import { printCommandError, printCommandResult } from "../output.js";
+
+function playwrightCliPath() {
+  return resolve("node_modules", "playwright-core", "cli.js");
+}
+
+export function registerDashboardCommand(program: Command): void {
+  const dashboard = program
+    .command("dashboard")
+    .description("Open Playwright's bundled session dashboard");
+
+  dashboard
+    .command("open")
+    .description("Open the Playwright session dashboard for human observation")
+    .option("--dry-run", "Validate the Playwright dashboard entrypoint without launching it")
+    .action(async (options: { dryRun?: boolean }) => {
+      const cli = playwrightCliPath();
+      if (!existsSync(cli)) {
+        printCommandError("dashboard open", {
+          code: "DASHBOARD_UNAVAILABLE",
+          message:
+            "Playwright dashboard entrypoint is unavailable in the installed playwright-core package",
+          retryable: false,
+          suggestions: [
+            "Run `pnpm install`",
+            "Use `pw session list --with-page` for a CLI-only session overview",
+          ],
+        });
+        process.exitCode = 1;
+        return;
+      }
+
+      if (options.dryRun) {
+        printCommandResult("dashboard open", {
+          data: { available: true, entrypoint: cli, launched: false },
+        });
+        return;
+      }
+
+      const child = spawn(process.execPath, [cli, "cli", "show"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+
+      printCommandResult("dashboard open", {
+        data: { launched: true, entrypoint: cli, command: "playwright cli show" },
+      });
+    });
+}

--- a/src/app/commands/dashboard.ts
+++ b/src/app/commands/dashboard.ts
@@ -1,11 +1,28 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { printCommandError, printCommandResult } from "../output.js";
 
-function playwrightCliPath() {
-  return resolve("node_modules", "playwright-core", "cli.js");
+function packageRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+}
+
+function playwrightDashboardPaths() {
+  const root = packageRoot();
+  return {
+    dashboardApp: resolve(
+      root,
+      "node_modules",
+      "playwright-core",
+      "lib",
+      "tools",
+      "dashboard",
+      "dashboardApp.js",
+    ),
+    entrypoint: resolve(root, "node_modules", "playwright-core", "cli.js"),
+  };
 }
 
 export function registerDashboardCommand(program: Command): void {
@@ -18,12 +35,20 @@ export function registerDashboardCommand(program: Command): void {
     .description("Open the Playwright session dashboard for human observation")
     .option("--dry-run", "Validate the Playwright dashboard entrypoint without launching it")
     .action(async (options: { dryRun?: boolean }) => {
-      const cli = playwrightCliPath();
-      if (!existsSync(cli)) {
+      const paths = playwrightDashboardPaths();
+      const entrypointAvailable = existsSync(paths.entrypoint);
+      const dashboardAppAvailable = existsSync(paths.dashboardApp);
+      if (!entrypointAvailable || !dashboardAppAvailable) {
         printCommandError("dashboard open", {
           code: "DASHBOARD_UNAVAILABLE",
           message:
             "Playwright dashboard entrypoint is unavailable in the installed playwright-core package",
+          details: {
+            dashboardApp: paths.dashboardApp,
+            dashboardAppAvailable,
+            entrypoint: paths.entrypoint,
+            entrypointAvailable,
+          },
           retryable: false,
           suggestions: [
             "Run `pnpm install`",
@@ -36,19 +61,29 @@ export function registerDashboardCommand(program: Command): void {
 
       if (options.dryRun) {
         printCommandResult("dashboard open", {
-          data: { available: true, entrypoint: cli, launched: false },
+          data: {
+            available: true,
+            dashboardApp: paths.dashboardApp,
+            entrypoint: paths.entrypoint,
+            launched: false,
+          },
         });
         return;
       }
 
-      const child = spawn(process.execPath, [cli, "cli", "show"], {
+      const child = spawn(process.execPath, [paths.entrypoint, "cli", "show"], {
         detached: true,
         stdio: "ignore",
       });
       child.unref();
 
       printCommandResult("dashboard open", {
-        data: { launched: true, entrypoint: cli, command: "playwright cli show" },
+        data: {
+          command: "playwright cli show",
+          dashboardApp: paths.dashboardApp,
+          entrypoint: paths.entrypoint,
+          launched: true,
+        },
       });
     });
 }

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -6,6 +6,7 @@ import { registerClickCommand } from "./click.js";
 import { registerCodeCommand } from "./code.js";
 import { registerConsoleCommand } from "./console.js";
 import { registerCookiesCommand } from "./cookies.js";
+import { registerDashboardCommand } from "./dashboard.js";
 import { registerDiagnosticsCommand } from "./diagnostics.js";
 import { registerDialogCommand } from "./dialog.js";
 import { registerDoctorCommand } from "./doctor.js";
@@ -43,6 +44,7 @@ export function registerCommands(program: Command): void {
   registerAuthCommand(program);
   registerBatchCommand(program);
   registerBootstrapCommand(program);
+  registerDashboardCommand(program);
   registerDiagnosticsCommand(program);
   registerDialogCommand(program);
   registerDoctorCommand(program);


### PR DESCRIPTION
## Summary
- Add `pw dashboard open` as a thin wrapper around Playwright-core session dashboard.
- Add dry-run smoke coverage and human-observation docs.
- Mark dashboard as skill-guided human takeover, not an Agent mainline step.

Refs #31

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43293 pnpm smoke`
- `node dist/cli.js dashboard open --dry-run`
- manual headed dashboard check with two sessions
- cwd-independent dry-run check from `/tmp`
- `git diff --check`