### PR TITLE
Report dashboard launch failures

### DIFF
--- a/docs/architecture/domain-status.md
+++ b/docs/architecture/domain-status.md
@@ -27,7 +27,7 @@
 
 - `session status` 只做快速状态检查；页面忙、弹窗阻塞、浏览器断连时可能拿不到完整页面信息，异常时用 `pw doctor --session <name>` 复查
 - `session attach --browser-url/--cdp` 只能接管当前机器上可连接的浏览器调试端口；连接失败时先确认浏览器是否用远程调试参数启动、端口是否可访问
-- `dashboard open` relies on an internal/hidden Playwright CLI surface and must fail as `DASHBOARD_UNAVAILABLE` if the entrypoint disappears.
+- `dashboard open` relies on an internal/hidden Playwright CLI surface and must fail as `DASHBOARD_UNAVAILABLE` if the entrypoint disappears, or `DASHBOARD_LAUNCH_FAILED` if the subprocess exits during startup.
 
 ### 后续扩展
 
@@ -255,4 +255,3 @@
 
 - 目标：周期性检查主 skill 到 references/workflows 的相对路径路由是否闭环、是否覆盖 70%+ 高频场景。
 - 验收：形成固定 checklist，并在每次命令 contract 变更时执行一次。
-

--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -209,6 +209,17 @@ log "dashboard dry run"
 dashboard_json="$(run_json dashboard-dry-run dashboard open --dry-run)"
 assert_json "$dashboard_json" "dashboard entrypoint is available" \
   "data.ok === true && data.data.available === true && data.data.launched === false && data.data.entrypoint.includes('playwright-core')"
+node --input-type=module <<'NODE'
+import { spawn } from 'node:child_process';
+import { observeDashboardLaunch } from './dist/app/commands/dashboard.js';
+
+const child = spawn(process.execPath, ['-e', 'process.exit(42)'], { stdio: 'ignore' });
+const failure = await observeDashboardLaunch(child, 1_000);
+if (!failure || failure.phase !== 'early-exit' || failure.code !== 42) {
+  console.error('[smoke] dashboard open must classify early subprocess launch failures');
+  process.exit(1);
+}
+NODE
 
 log "session create"
 create_json="$(run_json session-create session create "$SESSION_NAME" --open "$BLANK_URL")"

--- a/skills/pwcli/references/command-reference-advanced.md
+++ b/skills/pwcli/references/command-reference-advanced.md
@@ -111,6 +111,9 @@ Opens Playwright-core's bundled session dashboard. This is a thin wrapper around
 
 Use for human observation or takeover. Do not use as a required Agent workflow step.
 
+If the bundled entrypoint is missing, the command fails with `DASHBOARD_UNAVAILABLE`.
+If the dashboard subprocess exits during the startup observation window, the command fails with `DASHBOARD_LAUNCH_FAILED` instead of reporting `launched: true`.
+
 ## Environment
 
 ### `pw environment offline on|off --session <name>`

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -28,6 +28,38 @@ pw session list
 pw session create bug-a --open 'https://example.com'
 ```
 
+## Dashboard launch failures
+
+### `DASHBOARD_UNAVAILABLE`
+
+Meaning:
+
+- the installed `playwright-core` package does not expose the bundled dashboard entrypoint expected by `pw dashboard open`
+
+Recovery:
+
+```bash
+pnpm install
+pw dashboard open --dry-run
+pw session list --with-page
+```
+
+### `DASHBOARD_LAUNCH_FAILED`
+
+Meaning:
+
+- `pw dashboard open` found the bundled Playwright entrypoint, but the dashboard subprocess failed during startup
+- the command has not successfully launched a dashboard process
+
+Recovery:
+
+```bash
+pw dashboard open --dry-run
+pw session list --with-page
+```
+
+Use `session list --with-page` as the CLI-only fallback. Do not treat `DASHBOARD_LAUNCH_FAILED` as a launched dashboard.
+
 ## Modal blockage
 
 ### `REF_STALE`

--- a/src/app/commands/dashboard.ts
+++ b/src/app/commands/dashboard.ts
@@ -1,9 +1,15 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { printCommandError, printCommandResult } from "../output.js";
+
+const DASHBOARD_LAUNCH_OBSERVE_MS = 1_000;
+
+type DashboardLaunchFailure =
+  | { error: Error; phase: "spawn" }
+  | { code: number | null; phase: "early-exit"; signal: NodeJS.Signals | null };
 
 function packageRoot() {
   return resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -23,6 +29,39 @@ function playwrightDashboardPaths() {
     ),
     entrypoint: resolve(root, "node_modules", "playwright-core", "cli.js"),
   };
+}
+
+export function observeDashboardLaunch(
+  child: ChildProcess,
+  observeMs = DASHBOARD_LAUNCH_OBSERVE_MS,
+): Promise<DashboardLaunchFailure | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const onError = (error: Error) => {
+      finish({ error, phase: "spawn" });
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish({ code, phase: "early-exit", signal });
+    };
+    const finish = (result: DashboardLaunchFailure | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      child.off("error", onError);
+      child.off("exit", onExit);
+      resolve(result);
+    };
+
+    timer = setTimeout(() => finish(null), observeMs);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
 }
 
 export function registerDashboardCommand(program: Command): void {
@@ -75,6 +114,30 @@ export function registerDashboardCommand(program: Command): void {
         detached: true,
         stdio: "ignore",
       });
+      const launchFailure = await observeDashboardLaunch(child);
+      if (launchFailure) {
+        printCommandError("dashboard open", {
+          code: "DASHBOARD_LAUNCH_FAILED",
+          message: "Playwright dashboard subprocess failed during startup",
+          details: {
+            command: "playwright cli show",
+            dashboardApp: paths.dashboardApp,
+            entrypoint: paths.entrypoint,
+            observeMs: DASHBOARD_LAUNCH_OBSERVE_MS,
+            phase: launchFailure.phase,
+            ...(launchFailure.phase === "spawn"
+              ? { errorMessage: launchFailure.error.message }
+              : { exitCode: launchFailure.code, signal: launchFailure.signal }),
+          },
+          retryable: false,
+          suggestions: [
+            "Run `pw dashboard open --dry-run` to validate the bundled Playwright dashboard entrypoint",
+            "Use `pw session list --with-page` for a CLI-only session overview",
+          ],
+        });
+        process.exitCode = 1;
+        return;
+      }
       child.unref();
 
       printCommandResult("dashboard open", {


### PR DESCRIPTION
## Summary
- observe the Playwright dashboard subprocess startup before returning `launched: true`
- return `DASHBOARD_LAUNCH_FAILED` for spawn errors or early exits instead of silently detaching
- document dashboard launch recovery and add smoke coverage for early-exit classification

Follow-up to #46.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43298 pnpm smoke`
- `git diff --check`