### PR TITLE
Fix diagnostics bundle audit next steps

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -129,6 +129,46 @@ if ! curl -sf "$BLANK_URL" >/dev/null; then
   exit 1
 fi
 
+log "diagnostics audit conclusion domain contract"
+node --input-type=module <<'NODE'
+import assert from 'node:assert/strict';
+import { buildDiagnosticsAuditConclusion } from './dist/domain/diagnostics/service.js';
+
+const conclusion = buildDiagnosticsAuditConclusion({
+  sessionName: 'audit-smoke',
+  latestRunId: 'run-http-1',
+  limit: 20,
+  digestData: {
+    summary: {
+      pageErrorCount: 0,
+      failedRequestCount: 0,
+      consoleErrorCount: 0,
+      httpErrorCount: 1,
+    },
+    topSignals: [
+      {
+        kind: 'response',
+        summary: 'GET /api/failure -> 500',
+      },
+    ],
+  },
+  latestRunEvents: {
+    runId: 'run-http-1',
+    events: [
+      {
+        command: 'click',
+        ts: '2026-04-30T02:00:00.000Z',
+      },
+    ],
+  },
+});
+
+assert.equal(conclusion.status, 'failed_or_risky');
+assert.equal(conclusion.failureKind, 'response');
+assert.ok(conclusion.agentNextSteps.some((step) => step.includes('run-http-1')));
+assert.ok(conclusion.agentNextSteps.every((step) => !step.includes('<latestRunId>')));
+NODE
+
 log "action failure classifier contract"
 node --input-type=module <<'NODE'
 import { ActionFailure } from './dist/domain/interaction/action-failure.js';
@@ -640,6 +680,20 @@ pdf_json="$(run_json pdf-export pdf --session "$SESSION_NAME" --path "$pdf_path"
 assert_json "$pdf_json" "pdf export returns path" \
   "data.ok === true && data.data.path.endsWith('page.pdf') && data.data.saved === true && typeof data.data.run.runId === 'string'"
 test -s "$pdf_path"
+
+log "diagnostics bundle audit conclusion"
+bundle_http_json="$(run_json bundle-http-code code --session "$SESSION_NAME" "async page => { const response = await page.evaluate(async () => { const response = await fetch('/__pwcli__/bundle-http-error', { cache: 'no-store' }); return { status: response.status, text: await response.text() }; }); return response; }")"
+assert_json "$bundle_http_json" "bundle setup captured http error response without throwing" \
+  "data.ok === true && data.data.result.status === 404"
+bundle_dir="${TMP_DIR}/diag-bundle"
+bundle_json="$(run_json diagnostics-bundle diagnostics bundle --session "$SESSION_NAME" --out "$bundle_dir" --limit 20)"
+BUNDLE_RUN_ID="$(json_field "$bundle_json" "data.data.latestRunId")"
+assert_json "$bundle_json" "bundle audit conclusion reports risky signals" \
+  "data.ok === true && data.data.auditConclusion.status === 'failed_or_risky'"
+assert_json "$bundle_json" "bundle audit next steps contain executable run commands" \
+  "data.ok === true && data.data.auditConclusion.agentNextSteps.some(item => item.includes('${BUNDLE_RUN_ID}')) && data.data.auditConclusion.agentNextSteps.every(item => !item.includes('<latestRunId>'))"
+assert_json "${bundle_dir}/manifest.json" "bundle manifest mirrors executable audit next steps" \
+  "data.latestRunId === '${BUNDLE_RUN_ID}' && data.auditConclusion.agentNextSteps.some(item => item.includes('${BUNDLE_RUN_ID}')) && data.auditConclusion.agentNextSteps.every(item => !item.includes('<latestRunId>'))"
 
 log "fire diagnostics"
 diagnostics_restore_json="$(run_json diagnostics-restore code --session "$SESSION_NAME" --file ./scripts/manual/diagnostics-fixture.js)"

--- a/src/app/commands/diagnostics.ts
+++ b/src/app/commands/diagnostics.ts
@@ -1,11 +1,10 @@
-import { writeFile } from "node:fs/promises";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { Command } from "commander";
 import {
   listDiagnosticsRuns,
-  managedDiagnosticsDigest,
   managedDiagnosticsBundle,
+  managedDiagnosticsDigest,
   managedDiagnosticsExport,
   managedDiagnosticsExportFiltered,
   readDiagnosticsRunView,
@@ -139,7 +138,11 @@ export function registerDiagnosticsCommand(program: Command): void {
         const result = await managedDiagnosticsBundle({ sessionName, limit });
         const bundleDir = resolve(out);
         await mkdir(bundleDir, { recursive: true });
-        await writeFile(resolve(bundleDir, "manifest.json"), JSON.stringify(result.data, null, 2), "utf8");
+        await writeFile(
+          resolve(bundleDir, "manifest.json"),
+          JSON.stringify(result.data, null, 2),
+          "utf8",
+        );
         printCommandResult("diagnostics bundle", {
           session: result.session,
           page: result.page,

--- a/src/domain/diagnostics/service.ts
+++ b/src/domain/diagnostics/service.ts
@@ -392,7 +392,14 @@ function buildRunDigest(runId: string, events: RunEventRecord[], limit: number) 
   };
 }
 
-function buildAgentAuditConclusion(input: {
+function shellArg(value: string) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildDiagnosticsAuditConclusion(input: {
+  sessionName: string;
+  latestRunId: string | null;
+  limit: number;
   digestData: Record<string, unknown>;
   latestRunEvents: Record<string, unknown> | null;
 }) {
@@ -407,10 +414,24 @@ function buildAgentAuditConclusion(input: {
   const pageErrorCount = asNumber(summary.pageErrorCount) ?? 0;
   const failedRequestCount = asNumber(summary.failedRequestCount) ?? 0;
   const consoleErrorCount = asNumber(summary.consoleErrorCount) ?? 0;
-  const failureLikely = pageErrorCount > 0 || failedRequestCount > 0 || consoleErrorCount > 0;
+  const httpErrorCount = asNumber(summary.httpErrorCount) ?? 0;
+  const failureLikely =
+    pageErrorCount > 0 || failedRequestCount > 0 || consoleErrorCount > 0 || httpErrorCount > 0;
   const firstSignal = asObject(topSignals[0] ?? {});
   const failureKind = asString(firstSignal.kind) ?? null;
   const failureSummary = asString(firstSignal.summary) ?? null;
+  const latestRunId = input.latestRunId ?? asString(latestRunEvents.runId);
+  const limit = Math.max(1, input.limit);
+  const grepText = failureSummary ?? failureKind ?? "error";
+  const failureNextSteps = latestRunId
+    ? [
+        `run: pw diagnostics show --run ${shellArg(latestRunId)} --limit ${limit}`,
+        `run: pw diagnostics grep --run ${shellArg(latestRunId)} --text ${shellArg(grepText)} --limit ${limit}`,
+      ]
+    : [
+        `run: pw diagnostics digest --session ${shellArg(input.sessionName)} --limit ${Math.min(limit, 10)}`,
+        `run: pw diagnostics export --session ${shellArg(input.sessionName)} --out ./diag.json --limit ${limit}`,
+      ];
 
   return {
     status: failureLikely ? "failed_or_risky" : "no_strong_failure_signal",
@@ -423,8 +444,7 @@ function buildAgentAuditConclusion(input: {
       : "continue_workflow_or_run_targeted_assertions",
     agentNextSteps: failureLikely
       ? [
-          "run: pw diagnostics show --run <latestRunId> --limit 20",
-          "run: pw diagnostics grep --run <latestRunId> --text <error keyword> --limit 20",
+          ...failureNextSteps,
           "derive root cause hypothesis",
           "propose and apply minimal fix",
           "re-run validation commands",
@@ -613,10 +633,7 @@ export async function readDiagnosticsRunView(options: {
   };
 }
 
-export async function managedDiagnosticsBundle(options: {
-  sessionName: string;
-  limit?: number;
-}) {
+export async function managedDiagnosticsBundle(options: { sessionName: string; limit?: number }) {
   const limit = Math.max(1, options.limit ?? 20);
   const exported = await managedDiagnosticsExportFiltered({
     sessionName: options.sessionName,
@@ -638,7 +655,10 @@ export async function managedDiagnosticsBundle(options: {
         limit,
       })
     : null;
-  const auditConclusion = buildAgentAuditConclusion({
+  const auditConclusion = buildDiagnosticsAuditConclusion({
+    sessionName: options.sessionName,
+    latestRunId: latestRun?.runId ?? null,
+    limit,
     digestData: asObject(digest.data),
     latestRunEvents: latestRunView,
   });


### PR DESCRIPTION
## Summary

- Replaces `auditConclusion.agentNextSteps` placeholders with executable `pw diagnostics show|grep --run <actualRunId>` commands when a latest run exists.
- Treats digest `httpErrorCount` as a risky failure signal, matching `topSignals` and bundle triage semantics.
- Adds smoke coverage for the pure audit conclusion contract plus real `diagnostics bundle` manifest/CLI output.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43342 pnpm smoke`
- `git diff --check`

Fixes review findings from merged #49.