### PR TITLE
Add verify assertions for agent state checks

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -320,12 +320,42 @@ log "state check primitives"
 locate_json="$(run_json locate-text locate --session "$SESSION_NAME" --text "pwcli deterministic fixture")"
 assert_json "$locate_json" "locate text returns candidates" \
   "data.ok === true && data.data.count >= 1 && Array.isArray(data.data.candidates)"
+state_target_setup_json="$(run_json state-target-setup code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const main = document.querySelector('main'); const labelled = document.createElement('label'); labelled.textContent = 'State Email'; const labelledInput = document.createElement('input'); labelledInput.id = 'state-email'; labelledInput.value = 'agent@example.com'; labelled.appendChild(labelledInput); const placeholderInput = document.createElement('input'); placeholderInput.placeholder = 'State Search'; placeholderInput.value = 'query'; const firstRow = document.createElement('div'); firstRow.className = 'verify-row'; firstRow.textContent = 'row one'; const secondRow = document.createElement('div'); secondRow.className = 'verify-row'; secondRow.textContent = 'row two'; main.append(labelled, placeholderInput, firstRow, secondRow); }); return 'state-targets-ready'; }")"
+assert_json "$state_target_setup_json" "state target fixture installed" \
+  "data.ok === true && data.data.result === 'state-targets-ready'"
+label_get_json="$(run_json get-label get value --session "$SESSION_NAME" --label "State Email")"
+assert_json "$label_get_json" "get supports label target" \
+  "data.ok === true && data.data.value === 'agent@example.com'"
+placeholder_get_json="$(run_json get-placeholder get value --session "$SESSION_NAME" --placeholder "State Search")"
+assert_json "$placeholder_get_json" "get supports placeholder target" \
+  "data.ok === true && data.data.value === 'query'"
+nth_get_json="$(run_json get-nth get text --session "$SESSION_NAME" --selector ".verify-row" --nth 2)"
+assert_json "$nth_get_json" "get supports nth target disambiguation" \
+  "data.ok === true && data.data.value.includes('row two')"
 count_json="$(run_json get-count get count --session "$SESSION_NAME" --selector "body")"
 assert_json "$count_json" "get count returns number" \
   "data.ok === true && typeof data.data.value === 'number' && data.data.value >= 1"
 visible_json="$(run_json is-visible is visible --session "$SESSION_NAME" --selector "body")"
 assert_json "$visible_json" "is visible returns boolean" \
   "data.ok === true && data.data.value === true"
+verify_text_json="$(run_json verify-text verify text --session "$SESSION_NAME" --text "pwcli deterministic fixture")"
+assert_json "$verify_text_json" "verify text passes with compact assertion result" \
+  "data.ok === true && data.data.assertion === 'text' && data.data.passed === true && data.data.retryable === false && Array.isArray(data.data.suggestions)"
+verify_url_json="$(run_json verify-url verify url --session "$SESSION_NAME" --contains "/blank")"
+assert_json "$verify_url_json" "verify url contains passes" \
+  "data.ok === true && data.data.assertion === 'url' && data.data.passed === true && data.data.actual.includes('/blank')"
+verify_count_json="$(run_json verify-count verify count --session "$SESSION_NAME" --selector ".verify-row" --equals 2)"
+assert_json "$verify_count_json" "verify count equals passes" \
+  "data.ok === true && data.data.assertion === 'count' && data.data.passed === true && data.data.count === 2"
+verify_text_nth_missing_json="$(run_fail_json verify-text-nth-missing verify text --session "$SESSION_NAME" --selector ".verify-row" --nth 3)"
+assert_json "$verify_text_nth_missing_json" "verify text honors nth when indexed target is missing" \
+  "data.ok === false && data.error.code === 'VERIFY_FAILED' && data.error.details.assertion === 'text' && data.error.details.passed === false && data.error.details.count === 2"
+verify_text_absent_nth_json="$(run_json verify-text-absent-nth verify text-absent --session "$SESSION_NAME" --selector ".verify-row" --nth 3)"
+assert_json "$verify_text_absent_nth_json" "verify text-absent honors nth when indexed target is missing" \
+  "data.ok === true && data.data.assertion === 'text-absent' && data.data.passed === true && data.data.count === 2"
+verify_missing_json="$(run_fail_json verify-missing verify text --session "$SESSION_NAME" --text "missing verify smoke text")"
+assert_json "$verify_missing_json" "verify failure returns stable recovery envelope" \
+  "data.ok === false && data.error.code === 'VERIFY_FAILED' && data.error.retryable === true && data.error.details.assertion === 'text' && data.error.details.passed === false && data.error.suggestions.some(item => item.includes('read-text'))"
 missing_get_json="$(run_fail_json get-missing get text --session "$SESSION_NAME" --selector ".missing-state-target")"
 assert_json "$missing_get_json" "get missing target returns stable code" \
   "data.ok === false && data.error.code === 'STATE_TARGET_NOT_FOUND' && data.error.retryable === true"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -46,6 +46,7 @@ pw read-text -s bug-a --max-chars 2000
 pw locate -s bug-a --text '保存成功'
 pw get count -s bug-a --selector '.row'
 pw is visible -s bug-a --selector '#submit'
+pw verify text -s bug-a --text '保存成功'
 pw snapshot -i -s bug-a
 
 # 动作闭环
@@ -73,7 +74,7 @@ pw diagnostics digest -s bug-a
 | 继续当前页面 | `session list/status` | 用户明确说继续旧任务 |
 | 已有 session 导航 | `open` | 只换 URL，不换 browser shape |
 | 页面理解 | `observe status`、`page current`、`read-text` | 默认观察路径 |
-| 状态读取 | `locate`、`get`、`is` | 低噪声检查元素是否存在、读取事实或布尔状态 |
+| 状态读取 / 断言 | `locate`、`get`、`is`、`verify` | 低噪声检查元素是否存在、读取事实、布尔状态或可执行断言 |
 | 多页面切换 | `page list`、`tab select|close` | popup、新开页、OAuth/预览窗口 |
 | 结构定位 | `snapshot -i` / `snapshot` | 需要 aria ref 或页面结构 |
 | 页面动作 | `click/fill/type/press/scroll/drag` | 稳定动作，带 action 记录 |
@@ -141,6 +142,8 @@ pw read-text -s bug-a --max-chars 2000
 pw locate -s bug-a --text '提交'
 pw get text -s bug-a --selector '#result'
 pw is enabled -s bug-a --role button --name '提交'
+pw verify visible -s bug-a --role button --name '提交'
+pw verify text -s bug-a --text '保存成功'
 ```
 
 用途：
@@ -150,10 +153,11 @@ pw is enabled -s bug-a --role button --name '提交'
 - `read-text`：可见文本，适合快速理解页面。
 - `read-text --include-overlay`：点击 dropdown/modal/popover 后读取浮层文本。
 - `locate/get/is`：窄状态检查；只返回候选、事实或布尔值，不生成动作计划。
+- `verify`：动作和 wait 之后的 read-only 断言；通过/失败都给 Agent 可消费结果，失败返回 `VERIFY_FAILED`。
 - `snapshot -i`：只看可交互节点，找 ref 首选。
 - `snapshot`：完整结构树，需要理解页面层级时再用。
 
-`locate/get/is` 适合脚本断言和低噪声状态读取。需要 fresh ref 或页面结构时继续用 `snapshot -i`；不要把这些命令当 action planner。
+`locate/get/is/verify` 适合脚本断言和低噪声状态读取。需要 fresh ref 或页面结构时继续用 `snapshot -i`；不要把这些命令当 action planner。
 
 需要 ref 点击或结构定位：
 
@@ -216,7 +220,7 @@ pw wait -s bug-a --response '/api/items' --status 200
 ```bash
 pw click -s bug-a --text '提交'
 pw wait network-idle -s bug-a
-pw read-text -s bug-a --max-chars 2000
+pw verify text -s bug-a --text '保存成功'
 pw diagnostics digest -s bug-a
 ```
 

--- a/skills/pwcli/references/command-reference.md
+++ b/skills/pwcli/references/command-reference.md
@@ -80,7 +80,10 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 - `--selector <selector>`
 - `--text <text>`
 - `--role <role> --name <name>`
+- `--label <label>`
+- `--placeholder <text>`
 - `--testid <id>`
+- `--nth <n>`：1-based disambiguation
 
 ### `pw get <fact> --session <name>`
 
@@ -102,7 +105,30 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 
 目标同 `locate`。目标不存在时返回 `value: false` 和 `count: 0`。`checked` 只适合 checkbox/radio 等可检查控件。
 
-Use `locate/get/is` for narrow state checks. Use `snapshot -i` when you need fresh refs. Do not use these commands as an action planner.
+### `pw verify <assertion> --session <name>`
+
+Read-only assertion command for agent loops after actions and waits. Success returns `{ assertion, passed: true, actual, expected, target?, count?, retryable: false, suggestions: [] }`. Failure exits non-zero with `VERIFY_FAILED` and the same assertion result under `error.details`.
+
+Assertions:
+
+- `text` / `text-absent` with a target, usually `--text <text>`
+- `url` with exactly one of `--contains <text>` / `--equals <url>` / `--matches <regex>`
+- `visible` / `hidden`
+- `enabled` / `disabled`
+- `checked` / `unchecked`
+- `count` with `--equals <n>` / `--min <n>` / `--max <n>`
+
+Examples:
+
+```bash
+pw verify text --session bug-a --text '保存成功'
+pw verify visible --session bug-a --selector '#submit'
+pw verify enabled --session bug-a --role button --name '提交'
+pw verify url --session bug-a --contains '/dashboard'
+pw verify count --session bug-a --selector '.row' --equals 3
+```
+
+Use `locate/get/is/verify` for narrow state checks. Use `snapshot -i` when you need fresh refs. Do not use these commands as an action planner.
 
 ### `pw snapshot --session <name>`
 

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -124,6 +124,31 @@ pw snapshot -i --session bug-a
 
 `locate` and `get count` are the low-noise checks when zero matches is acceptable. Use `snapshot -i` only when you need fresh refs or structural context.
 
+### `VERIFY_FAILED`
+
+Meaning:
+
+- `pw verify` ran a read-only assertion and the assertion did not pass
+- the command did not mutate page state
+- `error.details` includes `assertion`, `passed: false`, `actual`, `expected`, and `target` / `count` when relevant
+
+Recovery depends on the assertion:
+
+```bash
+pw read-text --session bug-a --include-overlay --max-chars 4000
+pw locate --session bug-a --text '<expected text>'
+pw snapshot -i --session bug-a
+pw page current --session bug-a
+```
+
+If `VERIFY_FAILED` follows an action and the page state is unexpectedly wrong, collect the compact handoff bundle:
+
+```bash
+pw diagnostics bundle --session bug-a --limit 20
+```
+
+Do not treat `VERIFY_FAILED` as an action failure. It means the check completed and the observed state did not match the expectation.
+
 ### `MODAL_STATE_BLOCKED`
 
 Meaning:

--- a/src/app/commands/get.ts
+++ b/src/app/commands/get.ts
@@ -19,7 +19,10 @@ export function registerGetCommand(program: Command): void {
       .option("--text <text>", "Exact text locator")
       .option("--role <role>", "Role locator")
       .option("--name <name>", "Accessible name for --role")
-      .option("--testid <id>", "Test id locator"),
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index"),
   ).action(async (fact: string, options: StateTargetOptions & { session?: string }) => {
     try {
       const sessionName = requireSessionName(options);

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -43,6 +43,7 @@ import { registerTraceCommand } from "./trace.js";
 import { registerTypeCommand } from "./type.js";
 import { registerUncheckCommand } from "./uncheck.js";
 import { registerUploadCommand } from "./upload.js";
+import { registerVerifyCommand } from "./verify.js";
 import { registerWaitCommand } from "./wait.js";
 
 export function registerCommands(program: Command): void {
@@ -67,6 +68,7 @@ export function registerCommands(program: Command): void {
   registerLocateCommand(program);
   registerGetCommand(program);
   registerIsCommand(program);
+  registerVerifyCommand(program);
   registerFillCommand(program);
   registerTypeCommand(program);
   registerPressCommand(program);

--- a/src/app/commands/is.ts
+++ b/src/app/commands/is.ts
@@ -19,7 +19,10 @@ export function registerIsCommand(program: Command): void {
       .option("--text <text>", "Exact text locator")
       .option("--role <role>", "Role locator")
       .option("--name <name>", "Accessible name for --role")
-      .option("--testid <id>", "Test id locator"),
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index"),
   ).action(async (state: string, options: StateTargetOptions & { session?: string }) => {
     try {
       const sessionName = requireSessionName(options);

--- a/src/app/commands/locate.ts
+++ b/src/app/commands/locate.ts
@@ -12,12 +12,15 @@ export function registerLocateCommand(program: Command): void {
   addSessionOption(
     program
       .command("locate")
-      .description("Locate elements by selector, text, role/name, or test id")
+      .description("Locate elements by selector, text, role/name, label, placeholder, or test id")
       .option("--selector <selector>", "CSS selector")
       .option("--text <text>", "Exact text locator")
       .option("--role <role>", "Role locator")
       .option("--name <name>", "Accessible name for --role")
-      .option("--testid <id>", "Test id locator"),
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index"),
   ).action(async (options: StateTargetOptions & { session?: string }) => {
     try {
       const sessionName = requireSessionName(options);
@@ -32,7 +35,9 @@ export function registerLocateCommand(program: Command): void {
       printSessionAwareCommandError("locate", error, {
         code: "LOCATE_FAILED",
         message: "locate failed",
-        suggestions: ["Pass exactly one target: --selector, --text, --role, or --testid"],
+        suggestions: [
+          "Pass exactly one target: --selector, --text, --role, --label, --placeholder, or --testid",
+        ],
       });
       process.exitCode = 1;
     }

--- a/src/app/commands/state-target.ts
+++ b/src/app/commands/state-target.ts
@@ -5,22 +5,56 @@ export type StateTargetOptions = {
   text?: string;
   role?: string;
   name?: string;
+  label?: string;
+  placeholder?: string;
   testid?: string;
+  nth?: string;
 };
 
-export function parseStateTarget(options: StateTargetOptions): StateTarget {
-  const targets = [options.selector, options.text, options.role, options.testid].filter(Boolean);
-  if (targets.length !== 1) {
-    throw new Error("provide exactly one target: --selector, --text, --role, or --testid");
+function parseNth(value?: string): number | undefined {
+  if (!value) {
+    return undefined;
   }
+  const nth = Number(value);
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
+export function parseStateTarget(options: StateTargetOptions): StateTarget {
+  const targets = [
+    options.selector,
+    options.text,
+    options.role,
+    options.label,
+    options.placeholder,
+    options.testid,
+  ].filter(Boolean);
+  if (targets.length !== 1) {
+    throw new Error(
+      "provide exactly one target: --selector, --text, --role, --label, --placeholder, or --testid",
+    );
+  }
+  const nth = parseNth(options.nth);
   if (options.selector) {
-    return { selector: options.selector };
+    return { selector: options.selector, ...(nth ? { nth } : {}) };
   }
   if (options.text) {
-    return { text: options.text };
+    return { text: options.text, ...(nth ? { nth } : {}) };
   }
   if (options.role) {
-    return { role: options.role, ...(options.name ? { name: options.name } : {}) };
+    return {
+      role: options.role,
+      ...(options.name ? { name: options.name } : {}),
+      ...(nth ? { nth } : {}),
+    };
   }
-  return { testid: options.testid as string };
+  if (options.label) {
+    return { label: options.label, ...(nth ? { nth } : {}) };
+  }
+  if (options.placeholder) {
+    return { placeholder: options.placeholder, ...(nth ? { nth } : {}) };
+  }
+  return { testid: options.testid as string, ...(nth ? { nth } : {}) };
 }

--- a/src/app/commands/verify.ts
+++ b/src/app/commands/verify.ts
@@ -1,0 +1,150 @@
+import type { Command } from "commander";
+import {
+  managedVerify,
+  type VerifyAssertion,
+  type VerifyOptions,
+} from "../../domain/interaction/service.js";
+import { printCommandError, printCommandResult } from "../output.js";
+import {
+  addSessionOption,
+  printSessionAwareCommandError,
+  requireSessionName,
+} from "./session-options.js";
+import { parseStateTarget, type StateTargetOptions } from "./state-target.js";
+
+const assertions = new Set<VerifyAssertion>([
+  "text",
+  "text-absent",
+  "url",
+  "visible",
+  "hidden",
+  "enabled",
+  "disabled",
+  "checked",
+  "unchecked",
+  "count",
+]);
+
+type VerifyCommandOptions = StateTargetOptions & {
+  session?: string;
+  contains?: string;
+  equals?: string;
+  matches?: string;
+  min?: string;
+  max?: string;
+};
+
+function parseNumberOption(name: string, value?: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} requires a finite number`);
+  }
+  return parsed;
+}
+
+function parseVerifyOptions(
+  assertion: VerifyAssertion,
+  sessionName: string,
+  options: VerifyCommandOptions,
+): VerifyOptions {
+  if (assertion === "url") {
+    const urlTargets = [options.contains, options.equals, options.matches].filter(Boolean);
+    if (urlTargets.length !== 1) {
+      throw new Error("verify url requires exactly one of --contains, --equals, or --matches");
+    }
+    return {
+      sessionName,
+      assertion,
+      url: {
+        ...(options.contains ? { contains: options.contains } : {}),
+        ...(options.equals ? { equals: options.equals } : {}),
+        ...(options.matches ? { matches: options.matches } : {}),
+      },
+    };
+  }
+
+  if (assertion === "count") {
+    const equals = parseNumberOption("--equals", options.equals);
+    const min = parseNumberOption("--min", options.min);
+    const max = parseNumberOption("--max", options.max);
+    if (equals === undefined && min === undefined && max === undefined) {
+      throw new Error("verify count requires --equals, --min, or --max");
+    }
+    return {
+      sessionName,
+      assertion,
+      target: parseStateTarget(options),
+      count: {
+        ...(equals !== undefined ? { equals } : {}),
+        ...(min !== undefined ? { min } : {}),
+        ...(max !== undefined ? { max } : {}),
+      },
+    };
+  }
+
+  return {
+    sessionName,
+    assertion,
+    target: parseStateTarget(options),
+  };
+}
+
+export function registerVerifyCommand(program: Command): void {
+  addSessionOption(
+    program
+      .command("verify <assertion>")
+      .description("Run a deterministic read-only assertion against page state")
+      .option("--selector <selector>", "CSS selector")
+      .option("--text <text>", "Exact text locator")
+      .option("--role <role>", "Role locator")
+      .option("--name <name>", "Accessible name for --role")
+      .option("--label <label>", "Exact label locator")
+      .option("--placeholder <text>", "Exact placeholder locator")
+      .option("--testid <id>", "Test id locator")
+      .option("--nth <number>", "1-based match index")
+      .option("--contains <text>", "URL substring expectation for verify url")
+      .option("--equals <value>", "Exact expectation for verify url or count")
+      .option("--matches <regex>", "Regular expression expectation for verify url")
+      .option("--min <number>", "Minimum count expectation")
+      .option("--max <number>", "Maximum count expectation"),
+  ).action(async (rawAssertion: string, options: VerifyCommandOptions) => {
+    try {
+      if (!assertions.has(rawAssertion as VerifyAssertion)) {
+        throw new Error(
+          "verify assertion must be one of: text, text-absent, url, visible, hidden, enabled, disabled, checked, unchecked, count",
+        );
+      }
+      const assertion = rawAssertion as VerifyAssertion;
+      const sessionName = requireSessionName(options);
+      const result = await managedVerify(parseVerifyOptions(assertion, sessionName, options));
+      if (result.data.passed) {
+        printCommandResult("verify", result);
+        return;
+      }
+      printCommandError("verify", {
+        code: "VERIFY_FAILED",
+        message: `verify ${assertion} failed`,
+        retryable: Boolean(result.data.retryable),
+        suggestions: Array.isArray(result.data.suggestions)
+          ? result.data.suggestions.map(String)
+          : [],
+        details: result.data,
+      });
+      process.exitCode = 1;
+    } catch (error) {
+      printSessionAwareCommandError("verify", error, {
+        code: "VERIFY_FAILED",
+        message: "verify failed",
+        suggestions: [
+          "Use `pw verify text --session bug-a --text 'Saved'` for visible text",
+          "Use `pw verify visible --session bug-a --selector '#submit'` for target state",
+          "Use `pw verify url --session bug-a --contains '/dashboard'` for navigation",
+        ],
+      });
+      process.exitCode = 1;
+    }
+  });
+}

--- a/src/app/output.ts
+++ b/src/app/output.ts
@@ -349,18 +349,26 @@ function formatAction(command: string, result: CommandResult): string {
 
 function formatStateTarget(value: unknown): string {
   const target = asRecord(value);
+  const nth = asNumber(target.nth);
+  const nthSuffix = nth !== null ? ` nth=${nth}` : "";
   if (typeof target.selector === "string") {
-    return `selector=${target.selector}`;
+    return `selector=${target.selector}${nthSuffix}`;
   }
   if (typeof target.text === "string") {
-    return `text=${JSON.stringify(target.text)}`;
+    return `text=${JSON.stringify(target.text)}${nthSuffix}`;
   }
   if (typeof target.role === "string") {
     const name = typeof target.name === "string" ? ` name=${JSON.stringify(target.name)}` : "";
-    return `role=${target.role}${name}`;
+    return `role=${target.role}${name}${nthSuffix}`;
+  }
+  if (typeof target.label === "string") {
+    return `label=${JSON.stringify(target.label)}${nthSuffix}`;
+  }
+  if (typeof target.placeholder === "string") {
+    return `placeholder=${JSON.stringify(target.placeholder)}${nthSuffix}`;
   }
   if (typeof target.testid === "string") {
-    return `testid=${target.testid}`;
+    return `testid=${target.testid}${nthSuffix}`;
   }
   return stringifyValue(target);
 }
@@ -387,6 +395,17 @@ function formatStateCheck(command: string, result: CommandResult): string {
     return `get ${asString(result.data.fact) ?? "fact"}=${stringifyValue(result.data.value)} count=${count} ${target}`;
   }
   return `is ${asString(result.data.state) ?? "state"}=${String(Boolean(result.data.value))} count=${count} ${target}`;
+}
+
+function formatVerify(result: CommandResult): string {
+  const assertion = asString(result.data.assertion) ?? "assertion";
+  const passed = Boolean(result.data.passed);
+  const target = result.data.target ? ` ${formatStateTarget(result.data.target)}` : "";
+  const actual = "actual" in result.data ? ` actual=${stringifyValue(result.data.actual)}` : "";
+  const expected =
+    "expected" in result.data ? ` expected=${stringifyValue(result.data.expected)}` : "";
+  const count = asNumber(result.data.count);
+  return `verify ${assertion} passed=${passed}${target}${count !== null ? ` count=${count}` : ""}${actual}${expected}`;
 }
 
 function hasOutputFlag(name: string): boolean {
@@ -448,6 +467,9 @@ function formatCommandText(command: string, result: CommandResult): string {
   }
   if (command === "locate" || command === "get" || command === "is") {
     return formatStateCheck(command, result);
+  }
+  if (command === "verify") {
+    return formatVerify(result);
   }
   if (command === "snapshot") {
     return formatSnapshot(result);

--- a/src/domain/interaction/service.ts
+++ b/src/domain/interaction/service.ts
@@ -19,6 +19,9 @@ export {
   managedType,
   managedUncheck,
   managedUpload,
+  managedVerify,
   managedWait,
   type StateTarget,
+  type VerifyAssertion,
+  type VerifyOptions,
 } from "../../infra/playwright/runtime.js";

--- a/src/infra/playwright/runtime/state-checks.ts
+++ b/src/infra/playwright/runtime/state-checks.ts
@@ -1,10 +1,40 @@
 import { managedRunCode } from "./code.js";
 
 export type StateTarget =
-  | { selector: string }
-  | { text: string }
-  | { role: string; name?: string }
-  | { testid: string };
+  | { selector: string; nth?: number }
+  | { text: string; nth?: number }
+  | { role: string; name?: string; nth?: number }
+  | { label: string; nth?: number }
+  | { placeholder: string; nth?: number }
+  | { testid: string; nth?: number };
+
+export type VerifyAssertion =
+  | "text"
+  | "text-absent"
+  | "url"
+  | "visible"
+  | "hidden"
+  | "enabled"
+  | "disabled"
+  | "checked"
+  | "unchecked"
+  | "count";
+
+export type VerifyOptions = {
+  sessionName?: string;
+  assertion: VerifyAssertion;
+  target?: StateTarget;
+  url?: {
+    contains?: string;
+    equals?: string;
+    matches?: string;
+  };
+  count?: {
+    equals?: number;
+    min?: number;
+    max?: number;
+  };
+};
 
 type StateCandidate = {
   index: number;
@@ -14,6 +44,31 @@ type StateCandidate = {
 };
 
 function targetExpression(target: StateTarget) {
+  const nth = "nth" in target && target.nth ? Math.max(1, Math.floor(Number(target.nth))) : 1;
+  const locator = (() => {
+    if ("selector" in target) {
+      return `page.locator(${JSON.stringify(target.selector)})`;
+    }
+    if ("text" in target) {
+      return `page.getByText(${JSON.stringify(target.text)}, { exact: true })`;
+    }
+    if ("role" in target) {
+      return `page.getByRole(${JSON.stringify(target.role)}, ${
+        target.name ? `{ name: ${JSON.stringify(target.name)}, exact: true }` : "undefined"
+      })`;
+    }
+    if ("label" in target) {
+      return `page.getByLabel(${JSON.stringify(target.label)}, { exact: true })`;
+    }
+    if ("placeholder" in target) {
+      return `page.getByPlaceholder(${JSON.stringify(target.placeholder)}, { exact: true })`;
+    }
+    return `page.getByTestId(${JSON.stringify(target.testid)})`;
+  })();
+  return nth > 1 ? `${locator}.nth(${nth - 1})` : locator;
+}
+
+function targetBaseExpression(target: StateTarget) {
   if ("selector" in target) {
     return `page.locator(${JSON.stringify(target.selector)})`;
   }
@@ -24,6 +79,12 @@ function targetExpression(target: StateTarget) {
     return `page.getByRole(${JSON.stringify(target.role)}, ${
       target.name ? `{ name: ${JSON.stringify(target.name)}, exact: true }` : "undefined"
     })`;
+  }
+  if ("label" in target) {
+    return `page.getByLabel(${JSON.stringify(target.label)}, { exact: true })`;
+  }
+  if ("placeholder" in target) {
+    return `page.getByPlaceholder(${JSON.stringify(target.placeholder)}, { exact: true })`;
   }
   return `page.getByTestId(${JSON.stringify(target.testid)})`;
 }
@@ -52,7 +113,7 @@ export async function managedLocate(options: { sessionName?: string; target: Sta
   const result = await managedRunCode({
     sessionName: options.sessionName,
     source: `async page => {
-      const locator = ${targetExpression(options.target)};
+      const locator = ${targetBaseExpression(options.target)};
       const count = await locator.count();
       const candidates = await locator.evaluateAll(nodes => nodes.slice(0, 10).map((node, index) => ({
         index: index + 1,
@@ -85,18 +146,21 @@ export async function managedGetFact(options: {
     source: `async page => {
       const target = ${JSON.stringify(options.target)};
       const locator = ${targetExpression(options.target)};
-      const count = await locator.count();
+      const baseLocator = ${targetBaseExpression(options.target)};
+      const count = await baseLocator.count();
       if (${JSON.stringify(options.fact)} === 'count') {
         return JSON.stringify({ value: count, count });
       }
       if (count === 0) {
         throw new Error('STATE_TARGET_NOT_FOUND:' + JSON.stringify({ target }));
       }
-      const first = locator.first();
-      if (${JSON.stringify(options.fact)} === 'text') {
-        return JSON.stringify({ value: await first.textContent(), count });
+      if (typeof target.nth === 'number' && target.nth > count) {
+        throw new Error('STATE_TARGET_NOT_FOUND:' + JSON.stringify({ target, count }));
       }
-      return JSON.stringify({ value: await first.inputValue(), count });
+      if (${JSON.stringify(options.fact)} === 'text') {
+        return JSON.stringify({ value: await locator.textContent(), count });
+      }
+      return JSON.stringify({ value: await locator.inputValue(), count });
     }`,
   });
   const parsed = parsedObject(result.data.result);
@@ -121,7 +185,8 @@ export async function managedIsState(options: {
     sessionName: options.sessionName,
     source: `async page => {
       const locator = ${targetExpression(options.target)}.first();
-      const count = await locator.count();
+      const baseLocator = ${targetBaseExpression(options.target)};
+      const count = await baseLocator.count();
       if (count === 0) {
         return JSON.stringify({ value: false, count });
       }
@@ -143,6 +208,140 @@ export async function managedIsState(options: {
       state: options.state,
       value: Boolean(parsed.value),
       count: Number(parsed.count ?? 0),
+    },
+  };
+}
+
+function verifySuggestions(assertion: VerifyAssertion): string[] {
+  if (assertion === "url") {
+    return [
+      "Run `pw page current --session <name>` to inspect the active URL",
+      "Run `pw wait network-idle --session <name>` before retrying the assertion",
+    ];
+  }
+  if (assertion === "text" || assertion === "text-absent") {
+    return [
+      "Run `pw read-text --session <name> --include-overlay --max-chars 4000` to inspect visible text",
+      "Run `pw locate --session <name> --text '<text>'` to inspect text candidates",
+      "Run `pw diagnostics bundle --session <name> --limit 20` if the missing text follows an action",
+    ];
+  }
+  return [
+    "Run `pw locate --session <name> --selector '<selector>'` to inspect candidates",
+    "Run `pw snapshot -i --session <name>` when you need fresh refs",
+    "Run `pw diagnostics bundle --session <name> --limit 20` if the failed assertion follows an action",
+  ];
+}
+
+function parseVerifyPayload(value: unknown): {
+  passed: boolean;
+  actual?: unknown;
+  expected?: unknown;
+  count?: number;
+} {
+  const parsed = parsedObject(value);
+  return {
+    passed: Boolean(parsed.passed),
+    actual: parsed.actual,
+    expected: parsed.expected,
+    count: typeof parsed.count === "number" ? parsed.count : undefined,
+  };
+}
+
+export async function managedVerify(options: VerifyOptions) {
+  const suggestions = verifySuggestions(options.assertion);
+  if (options.assertion === "url") {
+    const result = await managedRunCode({
+      sessionName: options.sessionName,
+      source: `async page => {
+        const actual = page.url();
+        const expectation = ${JSON.stringify(options.url ?? {})};
+        let passed = false;
+        let expected = expectation;
+        if (typeof expectation.contains === 'string') {
+          passed = actual.includes(expectation.contains);
+          expected = { contains: expectation.contains };
+        } else if (typeof expectation.equals === 'string') {
+          passed = actual === expectation.equals;
+          expected = { equals: expectation.equals };
+        } else if (typeof expectation.matches === 'string') {
+          passed = new RegExp(expectation.matches).test(actual);
+          expected = { matches: expectation.matches };
+        }
+        return JSON.stringify({ passed, actual, expected });
+      }`,
+    });
+    const parsed = parseVerifyPayload(result.data.result);
+    return {
+      session: result.session,
+      page: result.page,
+      data: {
+        assertion: options.assertion,
+        passed: parsed.passed,
+        expected: parsed.expected,
+        actual: parsed.actual,
+        retryable: !parsed.passed,
+        suggestions: parsed.passed ? [] : suggestions,
+      },
+    };
+  }
+
+  if (!options.target) {
+    throw new Error("verify assertion requires a target");
+  }
+
+  const result = await managedRunCode({
+    sessionName: options.sessionName,
+    source: `async page => {
+      const assertion = ${JSON.stringify(options.assertion)};
+      const target = ${JSON.stringify(options.target)};
+      const countExpectation = ${JSON.stringify(options.count ?? {})};
+      const locator = ${targetExpression(options.target)};
+      const baseLocator = ${targetBaseExpression(options.target)};
+      const count = await baseLocator.count();
+      if (assertion === 'text' || assertion === 'text-absent') {
+        const nth = typeof target.nth === 'number' ? target.nth : 1;
+        const matched = count > 0 && nth <= count;
+        const passed = assertion === 'text' ? matched : !matched;
+        return JSON.stringify({ passed, actual: { count, nth, matched }, expected: target, count });
+      }
+      if (assertion === 'count') {
+        let passed = true;
+        if (typeof countExpectation.equals === 'number') passed = passed && count === countExpectation.equals;
+        if (typeof countExpectation.min === 'number') passed = passed && count >= countExpectation.min;
+        if (typeof countExpectation.max === 'number') passed = passed && count <= countExpectation.max;
+        return JSON.stringify({ passed, actual: count, expected: countExpectation, count });
+      }
+      if (count === 0) {
+        const hiddenPass = assertion === 'hidden';
+        return JSON.stringify({ passed: hiddenPass, actual: false, expected: assertion, count });
+      }
+      const value =
+        assertion === 'visible' || assertion === 'hidden'
+          ? await locator.isVisible()
+          : assertion === 'enabled' || assertion === 'disabled'
+            ? await locator.isEnabled()
+            : await locator.isChecked();
+      const passed =
+        assertion === 'hidden' || assertion === 'disabled' || assertion === 'unchecked'
+          ? !value
+          : value;
+      return JSON.stringify({ passed, actual: value, expected: assertion, count });
+    }`,
+  });
+  const parsed = parseVerifyPayload(result.data.result);
+  return {
+    session: result.session,
+    page: result.page,
+    data: {
+      assertion: options.assertion,
+      passed: parsed.passed,
+      target: options.target,
+      expected: parsed.expected,
+      actual: parsed.actual,
+      ...(typeof parsed.count === "number" ? { count: parsed.count } : {}),
+      retryable: !parsed.passed,
+      suggestions: parsed.passed ? [] : suggestions,
     },
   };
 }


### PR DESCRIPTION
## Summary

- Add `pw verify <assertion>` for read-only agent assertions across text, url, visibility, enabled, checked, and count checks.
- Extend state targets for `locate/get/is/verify` with `--label`, `--placeholder`, and `--nth` parity.
- Update pwcli skill usage truth and failure recovery for `VERIFY_FAILED`.

Refs #23

@codex please review.

## Test Plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `PWCLI_FIXTURE_PORT=43355 pnpm smoke`
- `git diff --check`