### PR TITLE
Add hover action primitive

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -306,6 +306,9 @@ run_json stale-navigate open --session "$STALE_SESSION" "${BLANK_URL}?stale-ref=
 stale_reuse_json="$(run_fail_json stale-reuse click "$stale_ref" --session "$STALE_SESSION")"
 assert_json "$stale_reuse_json" "stale ref reuse returns REF_STALE" \
   "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed' && data.error.suggestions.some(item => item.includes('snapshot -i'))"
+stale_hover_json="$(run_fail_json stale-hover hover "$stale_ref" --session "$STALE_SESSION")"
+assert_json "$stale_hover_json" "stale hover ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed' && data.error.suggestions.some(item => item.includes('snapshot -i'))"
 run_json stale-close session close "$STALE_SESSION" >/dev/null
 STALE_SESSION_CLOSED="1"
 
@@ -662,6 +665,34 @@ assert_json "$uncheck_json" "uncheck returns action evidence" \
 select_json="$(run_json select-option select --session "$SESSION_NAME" --selector '#smoke-select' b)"
 assert_json "$select_json" "select returns selected value" \
   "data.ok === true && data.data.selected === true && data.data.value === 'b' && data.data.values.includes('b') && typeof data.data.run.runId === 'string'"
+hover_fixture_json="$(run_json hover-fixture code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const trigger = document.createElement('button'); trigger.id = 'hover-smoke-trigger'; trigger.type = 'button'; trigger.textContent = 'hover smoke trigger'; const panel = document.createElement('div'); panel.id = 'hover-smoke-panel'; panel.textContent = 'hover smoke option'; panel.style.display = 'none'; trigger.addEventListener('mouseenter', () => { panel.style.display = 'block'; console.log('hover-smoke-fired'); }); document.body.append(trigger, panel); }); return 'hover-fixture-ready'; }")"
+assert_json "$hover_fixture_json" "hover fixture installed" \
+  "data.ok === true && data.data.result === 'hover-fixture-ready'"
+hover_selector_json="$(run_json hover-selector hover --session "$SESSION_NAME" --selector '#hover-smoke-trigger')"
+assert_json "$hover_selector_json" "hover selector returns action evidence" \
+  "data.ok === true && data.data.acted === true && data.data.selector === '#hover-smoke-trigger' && data.data.diagnosticsDelta.consoleDelta >= 1 && typeof data.data.run.runId === 'string'"
+hover_text_json="$(run_json hover-read-text read-text --session "$SESSION_NAME" --max-chars 4000)"
+assert_json "$hover_text_json" "hover changed visible page state" \
+  "data.ok === true && data.data.text.includes('hover smoke option')"
+hover_snapshot_json="$(run_json hover-snapshot snapshot -i --session "$SESSION_NAME")"
+hover_ref="$(node - "$hover_snapshot_json" <<'NODE'
+const fs = require('node:fs');
+
+const payload = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const line = String(payload.data.snapshot || '')
+  .split('\n')
+  .find(item => item.includes('hover smoke trigger') && item.includes('[ref='));
+const match = line && line.match(/\[ref=(e[0-9]+)\]/);
+if (!match) {
+  console.error('[smoke] could not find hover trigger ref in fixture snapshot');
+  process.exit(1);
+}
+process.stdout.write(match[1]);
+NODE
+)"
+hover_ref_json="$(run_json hover-ref hover "$hover_ref" --session "$SESSION_NAME")"
+assert_json "$hover_ref_json" "hover ref returns action evidence" \
+  "data.ok === true && data.data.acted === true && data.data.ref === '${hover_ref}' && typeof data.data.run.runId === 'string'"
 
 log "storage mutation"
 storage_set_json="$(run_json storage-set storage local set --session "$SESSION_NAME" smokeFlag enabled)"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -76,7 +76,7 @@ pw diagnostics digest -s bug-a
 | 状态读取 | `locate`、`get`、`is` | 低噪声检查元素是否存在、读取事实或布尔状态 |
 | 多页面切换 | `page list`、`tab select|close` | popup、新开页、OAuth/预览窗口 |
 | 结构定位 | `snapshot -i` / `snapshot` | 需要 aria ref 或页面结构 |
-| 页面动作 | `click/fill/type/press/scroll/drag` | 稳定动作，带 action 记录 |
+| 页面动作 | `click/fill/type/press/hover/scroll/drag` | 稳定动作，带 action 记录 |
 | 文件交互 | `upload/download` | 上传文件、验证下载 |
 | 等待状态 | `wait` | 动作后依赖页面变化 |
 | 快速脚本 | `code` | 多状态读取、组合动作、能力未覆盖 |
@@ -198,6 +198,8 @@ pw press Enter -s bug-a
 pw type -s bug-a --selector 'textarea' 'hello'
 pw check -s bug-a --selector '#agree'
 pw select -s bug-a --selector '#country' jp
+pw hover -s bug-a --selector '.menu-trigger'
+pw hover e42 -s bug-a
 pw scroll down 800 -s bug-a
 pw drag -s bug-a --from-selector '.source' --to-selector '.target'
 ```

--- a/skills/pwcli/references/command-reference.md
+++ b/skills/pwcli/references/command-reference.md
@@ -145,6 +145,12 @@ Use `locate/get/is` for narrow state checks. Use `snapshot -i` when you need fre
 
 ### `pw press <key> --session <name>`
 
+### `pw hover [ref] --session <name>`
+
+- `--selector <selector>`
+- 支持 hover 触发的 menu / popover / tooltip；输出复用 action evidence：`target`、`diagnosticsDelta`、`run`
+- hover 后需要读取浮层时，用 `pw read-text --session <name> --include-overlay`
+
 ### `pw check [ref] --session <name>`
 
 - `--selector <selector>`

--- a/skills/pwcli/workflows/browser-task.md
+++ b/skills/pwcli/workflows/browser-task.md
@@ -59,6 +59,7 @@ pw fill -s <name> --selector '<selector>' '<value>'
 pw click -s <name> --role button --name '<name>'
 pw click -s <name> --text '<text>'
 pw click e42 -s <name>
+pw hover -s <name> --selector '<selector>'
 ```
 
 动作后等待：

--- a/src/app/commands/hover.ts
+++ b/src/app/commands/hover.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+import { managedHover } from "../../domain/interaction/service.js";
+import { printCommandResult } from "../output.js";
+import {
+  addSessionOption,
+  printSessionAwareCommandError,
+  requireSessionName,
+} from "./session-options.js";
+
+export function registerHoverCommand(program: Command): void {
+  addSessionOption(
+    program
+      .command("hover [ref]")
+      .description("Hover an element by aria ref or selector")
+      .option("--selector <selector>", "Selector target"),
+  ).action(async (ref: string | undefined, options: { selector?: string; session?: string }) => {
+    try {
+      const sessionName = requireSessionName(options);
+      printCommandResult(
+        "hover",
+        await managedHover({
+          ref,
+          selector: options.selector,
+          sessionName,
+        }),
+      );
+    } catch (error) {
+      printSessionAwareCommandError("hover", error, {
+        code: "HOVER_FAILED",
+        message: "hover failed",
+        suggestions: [
+          "Use `pw hover --session bug-a e6` or `pw hover --session bug-a --selector '.menu-trigger'`",
+          "If the page changed, refresh refs with `pw snapshot -i --session <name>`",
+          "After hovering, inspect revealed menus with `pw read-text --session <name> --include-overlay`",
+        ],
+      });
+      process.exitCode = 1;
+    }
+  });
+}

--- a/src/app/commands/index.ts
+++ b/src/app/commands/index.ts
@@ -18,6 +18,7 @@ import { registerErrorsCommand } from "./errors.js";
 import { registerFillCommand } from "./fill.js";
 import { registerGetCommand } from "./get.js";
 import { registerHarCommand } from "./har.js";
+import { registerHoverCommand } from "./hover.js";
 import { registerIsCommand } from "./is.js";
 import { registerLocateCommand } from "./locate.js";
 import { registerNetworkCommand } from "./network.js";
@@ -70,6 +71,7 @@ export function registerCommands(program: Command): void {
   registerFillCommand(program);
   registerTypeCommand(program);
   registerPressCommand(program);
+  registerHoverCommand(program);
   registerScrollCommand(program);
   registerSelectCommand(program);
   registerUncheckCommand(program);

--- a/src/app/output.ts
+++ b/src/app/output.ts
@@ -477,6 +477,7 @@ function formatCommandText(command: string, result: CommandResult): string {
       "fill",
       "type",
       "press",
+      "hover",
       "wait",
       "scroll",
       "upload",

--- a/src/domain/interaction/service.ts
+++ b/src/domain/interaction/service.ts
@@ -6,6 +6,7 @@ export {
   managedDrag,
   managedFill,
   managedGetFact,
+  managedHover,
   managedIsState,
   managedLocate,
   managedPdf,

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -700,6 +700,77 @@ export async function managedCheck(options: {
   return managedBooleanControlAction("check", options);
 }
 
+export async function managedHover(options: {
+  ref?: string;
+  selector?: string;
+  sessionName?: string;
+}) {
+  if (!options.ref && !options.selector) {
+    throw new Error("hover requires a ref or selector");
+  }
+
+  const before = await captureDiagnosticsBaseline(options.sessionName);
+
+  if (options.selector) {
+    const result = await managedActionRunCode({
+      command: "hover",
+      sessionName: options.sessionName,
+      source: `async page => {
+        await page.locator(${JSON.stringify(options.selector)}).hover();
+        return JSON.stringify({ acted: true });
+      }`,
+    });
+    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+    const run = await recordRun("hover", options.sessionName, result.page, {
+      target: { selector: options.selector },
+      diagnosticsDelta,
+    });
+    return {
+      session: result.session,
+      page: result.page,
+      data: {
+        selector: options.selector,
+        acted: true,
+        diagnosticsDelta,
+        run,
+      },
+    };
+  }
+
+  const ref = normalizeRef(options.ref ?? "");
+  await assertFreshRefEpoch({ sessionName: options.sessionName, ref });
+  const result = await runManagedSessionCommand(
+    {
+      _: ["hover", ref],
+    },
+    {
+      sessionName: options.sessionName,
+    },
+  );
+  throwIfManagedActionError(result.text, { command: "hover", sessionName: options.sessionName });
+
+  const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+  const run = await recordRun("hover", options.sessionName, parsePageSummary(result.text), {
+    target: { ref },
+    diagnosticsDelta,
+  });
+  return {
+    session: {
+      scope: "managed",
+      name: result.sessionName,
+      default: result.sessionName === "default",
+    },
+    page: parsePageSummary(result.text),
+    data: {
+      ref,
+      acted: true,
+      diagnosticsDelta,
+      run,
+      ...maybeRawOutput(result.text),
+    },
+  };
+}
+
 export async function managedUncheck(options: {
   ref?: string;
   selector?: string;


### PR DESCRIPTION
Refs #36

@codex please review

## Summary
- add `pw hover` for ref and `--selector` targets with session-aware errors
- record hover action evidence with diagnostics delta and run metadata
- cover selector hover, ref hover, and stale-ref hover recovery in smoke
- sync pwcli skill and command references

## Test Plan
- red: `pnpm build && PWCLI_FIXTURE_PORT=43361 pnpm smoke` failed at `error: unknown command 'hover'`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `PWCLI_FIXTURE_PORT=43363 pnpm smoke`
- `node dist/cli.js hover --help`