### PR TITLE
Apply nth to locate candidates

### DIFF
--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -323,7 +323,7 @@ log "state check primitives"
 locate_json="$(run_json locate-text locate --session "$SESSION_NAME" --text "pwcli deterministic fixture")"
 assert_json "$locate_json" "locate text returns candidates" \
   "data.ok === true && data.data.count >= 1 && Array.isArray(data.data.candidates)"
-state_target_setup_json="$(run_json state-target-setup code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const main = document.querySelector('main'); const labelled = document.createElement('label'); labelled.textContent = 'State Email'; const labelledInput = document.createElement('input'); labelledInput.id = 'state-email'; labelledInput.value = 'agent@example.com'; labelled.appendChild(labelledInput); const placeholderInput = document.createElement('input'); placeholderInput.placeholder = 'State Search'; placeholderInput.value = 'query'; const firstRow = document.createElement('div'); firstRow.className = 'verify-row'; firstRow.textContent = 'row one'; const secondRow = document.createElement('div'); secondRow.className = 'verify-row'; secondRow.textContent = 'row two'; main.append(labelled, placeholderInput, firstRow, secondRow); }); return 'state-targets-ready'; }")"
+state_target_setup_json="$(run_json state-target-setup code --session "$SESSION_NAME" "async page => { await page.evaluate(() => { const main = document.querySelector('main'); const labelled = document.createElement('label'); labelled.textContent = 'State Email'; const labelledInput = document.createElement('input'); labelledInput.id = 'state-email'; labelledInput.value = 'agent@example.com'; labelled.appendChild(labelledInput); const placeholderInput = document.createElement('input'); placeholderInput.placeholder = 'State Search'; placeholderInput.value = 'query'; const firstRow = document.createElement('div'); firstRow.className = 'verify-row'; firstRow.textContent = 'row one'; const secondRow = document.createElement('div'); secondRow.className = 'verify-row'; secondRow.textContent = 'row two'; const manyRows = Array.from({ length: 12 }, (_, index) => { const row = document.createElement('div'); row.className = 'locate-many-row'; row.textContent = 'locate many row ' + (index + 1); return row; }); main.append(labelled, placeholderInput, firstRow, secondRow, ...manyRows); }); return 'state-targets-ready'; }")"
 assert_json "$state_target_setup_json" "state target fixture installed" \
   "data.ok === true && data.data.result === 'state-targets-ready'"
 label_get_json="$(run_json get-label get value --session "$SESSION_NAME" --label "State Email")"
@@ -335,6 +335,12 @@ assert_json "$placeholder_get_json" "get supports placeholder target" \
 nth_get_json="$(run_json get-nth get text --session "$SESSION_NAME" --selector ".verify-row" --nth 2)"
 assert_json "$nth_get_json" "get supports nth target disambiguation" \
   "data.ok === true && data.data.value.includes('row two')"
+locate_nth_json="$(run_json locate-nth locate --session "$SESSION_NAME" --selector ".verify-row" --nth 2)"
+assert_json "$locate_nth_json" "locate supports nth target disambiguation" \
+  "data.ok === true && data.data.count === 2 && data.data.candidates.length === 1 && data.data.candidates[0].index === 2 && data.data.candidates[0].text.includes('row two')"
+locate_many_json="$(run_json locate-many locate --session "$SESSION_NAME" --selector ".locate-many-row")"
+assert_json "$locate_many_json" "locate preserves total count when candidates are capped" \
+  "data.ok === true && data.data.count === 12 && data.data.candidates.length === 10"
 count_json="$(run_json get-count get count --session "$SESSION_NAME" --selector "body")"
 assert_json "$count_json" "get count returns number" \
   "data.ok === true && typeof data.data.value === 'number' && data.data.value >= 1"

--- a/src/infra/playwright/runtime/state-checks.ts
+++ b/src/infra/playwright/runtime/state-checks.ts
@@ -114,13 +114,18 @@ export async function managedLocate(options: { sessionName?: string; target: Sta
     sessionName: options.sessionName,
     source: `async page => {
       const locator = ${targetBaseExpression(options.target)};
+      const target = ${JSON.stringify(options.target)};
+      const nth = typeof target.nth === 'number' ? Math.max(1, Math.floor(target.nth)) : null;
       const count = await locator.count();
-      const candidates = await locator.evaluateAll(nodes => nodes.slice(0, 10).map((node, index) => ({
-        index: index + 1,
-        text: (node.textContent || '').trim().slice(0, 160),
-        tagName: node.tagName.toLowerCase(),
-        visible: !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length),
-      })));
+      const candidates = await locator.evaluateAll((nodes, nth) => {
+        const selected = nth ? nodes.slice(nth - 1, nth) : nodes.slice(0, 10);
+        return selected.map((node, index) => ({
+          index: nth ? nth : index + 1,
+          text: (node.textContent || '').trim().slice(0, 160),
+          tagName: node.tagName.toLowerCase(),
+          visible: !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length),
+        }));
+      }, nth);
       return JSON.stringify({ count, candidates });
     }`,
   });


### PR DESCRIPTION
Fixes the post-merge review findings from #51/#53.

@codex please review

## Summary
- make `pw locate --nth N` narrow only the returned candidate list
- preserve full `locator.count()` in `data.count` for normal and indexed locate calls
- preserve original 1-based candidate index in locate output
- add smoke coverage for indexed locate disambiguation and capped candidate lists with total count > 10

## Test Plan
- red: `PWCLI_FIXTURE_PORT=43365 pnpm smoke` failed because locate `--nth 2` returned both `.verify-row` candidates
- red: `PWCLI_FIXTURE_PORT=43367 pnpm smoke` failed because locate `--nth 2` reported `count: 1` instead of total `2`
- `PWCLI_FIXTURE_PORT=43368 pnpm smoke`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`