### PR TITLE
fix core convergence contracts

### DIFF
--- a/docs/architecture/domain-status.md
+++ b/docs/architecture/domain-status.md
@@ -83,13 +83,13 @@
 - snapshot refs are not stable cross-navigation identifiers; after navigation, tab switch, or a new snapshot, old refs fail as `REF_STALE`
 - `batch` 当前只做单 session 串行执行，不做 lifecycle / environment / diagnostics query 容器
 - dialog 恢复当前只覆盖 browser dialog handle，不覆盖更复杂的页面级阻断控件
-- `locate|get|is` 只做 read-only state check；不返回 ref、不规划动作、不包含 `verify`
+- `locate|get|is|verify` 只做 read-only state check；不返回 ref、不规划动作
 - `get value` 依赖 Playwright `inputValue()`，只适合 input/textarea/select 等表单控件
 
 ### 后续扩展
 
 - batch 只在真实高频场景下增量扩命令，不追求全量 parity
-- `verify` 留在 #23 后续切片，不进入当前 MVP
+- `verify` 后续只补真实场景断言覆盖，不扩大成动作规划器
 
 ## 4. Identity State
 

--- a/docs/architecture/workspace-mutation-contract.md
+++ b/docs/architecture/workspace-mutation-contract.md
@@ -21,7 +21,7 @@
 
 - `tab select <pageId>`
 - `tab close <pageId>`
-- ref-backed interaction writes (`click` / `fill` / `type`) guarded by snapshot epoch
+- ref-backed interaction/evidence targets guarded by snapshot epoch
 
 运行时里已经存在这些 identity：
 
@@ -58,6 +58,8 @@ workspace mutation 唯一稳定 target id 用：
 - URL substring
 
 这些都只能作为读侧辅助信息，不适合作为 mutation contract。
+
+实现边界：Playwright Core 当前只通过 `tab-select <index>` 改 daemon active tab。`pwcli` 对外仍只接受 `pageId`，内部从最新 workspace projection 解析 index，调用 Core 后立即用 `page current` 校验 active `pageId`。如果期间 index 漂移，必须失败为 `TAB_PAGE_SELECTION_RACE`，不能报告成功。
 
 ### 3. `tab close`
 
@@ -100,7 +102,7 @@ Ref-backed writes require a fresh snapshot epoch for the active page identity. A
 - `url`
 - captured refs
 
-`click` / `fill` / `type` ref paths must validate the ref against that latest epoch before reporting `acted` / `filled` / `typed` success. Missing snapshot, missing ref, page switch, and navigation change all fail as `REF_STALE`.
+All ref-backed mutation and evidence-target paths must validate the ref against that latest epoch before reporting success. This includes `click`, `fill`, `type`, `hover`, `check`, `uncheck`, `select`, `upload`, `drag`, `download`, and ref-scoped `screenshot`. Missing snapshot, missing ref, page switch, and navigation change all fail as `REF_STALE`.
 
 ## 当前结论
 

--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -309,6 +309,24 @@ assert_json "$stale_reuse_json" "stale ref reuse returns REF_STALE" \
 stale_hover_json="$(run_fail_json stale-hover hover "$stale_ref" --session "$STALE_SESSION")"
 assert_json "$stale_hover_json" "stale hover ref reuse returns REF_STALE" \
   "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed' && data.error.suggestions.some(item => item.includes('snapshot -i'))"
+stale_screenshot_json="$(run_fail_json stale-screenshot screenshot "$stale_ref" --session "$STALE_SESSION" --path "${TMP_DIR}/stale-ref.png")"
+assert_json "$stale_screenshot_json" "stale screenshot ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
+stale_check_json="$(run_fail_json stale-check check "$stale_ref" --session "$STALE_SESSION")"
+assert_json "$stale_check_json" "stale check ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
+stale_select_json="$(run_fail_json stale-select select "$stale_ref" value --session "$STALE_SESSION")"
+assert_json "$stale_select_json" "stale select ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
+stale_upload_json="$(run_fail_json stale-upload upload "$stale_ref" "$HEADERS_FILE" --session "$STALE_SESSION")"
+assert_json "$stale_upload_json" "stale upload ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
+stale_drag_json="$(run_fail_json stale-drag drag "$stale_ref" "$stale_ref" --session "$STALE_SESSION")"
+assert_json "$stale_drag_json" "stale drag ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
+stale_download_json="$(run_fail_json stale-download download "$stale_ref" --session "$STALE_SESSION" --path "${TMP_DIR}/stale-download.bin")"
+assert_json "$stale_download_json" "stale download ref reuse returns REF_STALE" \
+  "data.ok === false && data.error.code === 'REF_STALE' && data.error.retryable === false && data.error.details.reason === 'navigation-changed'"
 run_json stale-close session close "$STALE_SESSION" >/dev/null
 STALE_SESSION_CLOSED="1"
 
@@ -350,6 +368,9 @@ assert_json "$visible_json" "is visible returns boolean" \
 verify_text_json="$(run_json verify-text verify text --session "$SESSION_NAME" --text "pwcli deterministic fixture")"
 assert_json "$verify_text_json" "verify text passes with compact assertion result" \
   "data.ok === true && data.data.assertion === 'text' && data.data.passed === true && data.data.retryable === false && Array.isArray(data.data.suggestions)"
+invalid_action_nth_json="$(run_fail_json invalid-action-nth click --session "$SESSION_NAME" --text "pwcli deterministic fixture" --nth nope)"
+assert_json "$invalid_action_nth_json" "action semantic nth rejects non-integer input" \
+  "data.ok === false && data.error.code === 'CLICK_FAILED' && data.error.message.includes('--nth requires a positive integer')"
 verify_url_json="$(run_json verify-url verify url --session "$SESSION_NAME" --contains "/blank")"
 assert_json "$verify_url_json" "verify url contains passes" \
   "data.ok === true && data.data.assertion === 'url' && data.data.passed === true && data.data.actual.includes('/blank')"
@@ -364,7 +385,7 @@ assert_json "$verify_text_absent_nth_json" "verify text-absent honors nth when i
   "data.ok === true && data.data.assertion === 'text-absent' && data.data.passed === true && data.data.count === 2"
 verify_missing_json="$(run_fail_json verify-missing verify text --session "$SESSION_NAME" --text "missing verify smoke text")"
 assert_json "$verify_missing_json" "verify failure returns stable recovery envelope" \
-  "data.ok === false && data.error.code === 'VERIFY_FAILED' && data.error.retryable === true && data.error.details.assertion === 'text' && data.error.details.passed === false && data.error.suggestions.some(item => item.includes('read-text'))"
+  "data.ok === false && data.error.code === 'VERIFY_FAILED' && data.error.retryable === true && data.error.details.assertion === 'text' && data.error.details.passed === false && data.error.suggestions.some(item => item.includes('read-text')) && data.error.suggestions.some(item => item.includes('diagnostics bundle') && item.includes('--out'))"
 missing_get_json="$(run_fail_json get-missing get text --session "$SESSION_NAME" --selector ".missing-state-target")"
 assert_json "$missing_get_json" "get missing target returns stable code" \
   "data.ok === false && data.error.code === 'STATE_TARGET_NOT_FOUND' && data.error.retryable === true"
@@ -490,14 +511,35 @@ assert_json "$batch_json" "batch summary reflects successful execution" \
   "data.ok === true && data.data.summary.stepCount === 2 && data.data.summary.successCount === 2 && data.data.summary.failedCount === 0 && data.data.summary.firstFailedStep === null"
 
 batch_fail_out="${TMP_DIR}/batch-fail.json"
-if ! printf '[ [\"session\",\"list\"] ]' | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json >"$batch_fail_out"; then
-  log "command failed: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json"
+set +e
+printf '[["session","list"]]' | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json >"$batch_fail_out"
+batch_fail_code=$?
+set -e
+if [ "$batch_fail_code" -eq 0 ]; then
+  log "expected batch failure: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json"
   cat "$batch_fail_out" >&2 || true
   exit 1
 fi
 batch_fail_json="$batch_fail_out"
 assert_json "$batch_fail_json" "batch failed step exposes summary and reason code" \
-  "data.ok === true && data.data.summary.stepCount === 1 && data.data.summary.successCount === 0 && data.data.summary.failedCount === 1 && data.data.summary.firstFailedStep === 1 && data.data.summary.firstFailedCommand === 'session' && data.data.summary.failedSteps.length === 1 && data.data.summary.failedSteps[0].step === 1 && data.data.summary.failedSteps[0].command === 'session' && Array.isArray(data.data.results) && data.data.results.length === 1 && data.data.results[0].ok === false"
+  "data.ok === false && data.error.code === 'BATCH_STEP_FAILED' && data.error.details.summary.stepCount === 1 && data.error.details.summary.successCount === 0 && data.error.details.summary.failedCount === 1 && data.error.details.summary.firstFailedStep === 1 && data.error.details.summary.firstFailedCommand === 'session' && data.error.details.summary.failedSteps.length === 1 && data.error.details.summary.failedSteps[0].step === 1 && data.error.details.summary.failedSteps[0].command === 'session' && Array.isArray(data.error.details.results) && data.error.details.results.length === 1 && data.error.details.results[0].ok === false"
+
+batch_continue_out="${TMP_DIR}/batch-continue.json"
+batch_continue_steps="$(node --input-type=module <<'NODE'
+console.log(JSON.stringify([
+  ["code", "async page => { throw new Error('batch continue smoke failure'); }"],
+  ["observe", "status"]
+]));
+NODE
+)"
+if ! printf '%s' "$batch_continue_steps" | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json --continue-on-error >"$batch_continue_out"; then
+  log "command failed: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json --continue-on-error"
+  cat "$batch_continue_out" >&2 || true
+  exit 1
+fi
+batch_continue_json="$batch_continue_out"
+assert_json "$batch_continue_json" "batch continue-on-error preserves success envelope for collection" \
+  "data.ok === true && data.data.summary.stepCount === 2 && data.data.summary.successCount === 1 && data.data.summary.failedCount === 1 && data.data.results.length === 2 && data.data.results[0].ok === false && data.data.results[0].error.message.includes('batch continue smoke failure') && data.data.results[1].ok === true"
 
 batch_verbose_out="${TMP_DIR}/batch-verbose.json"
 if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" --output json batch --session "$SESSION_NAME" --stdin-json --include-results >"$batch_verbose_out"; then
@@ -533,9 +575,17 @@ if grep -q '"results"' "$batch_text_out"; then
 fi
 
 batch_text_fail_out="${TMP_DIR}/batch-text-fail.txt"
+set +e
 printf '[["session","list"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$batch_text_fail_out"
-if ! grep -q 'first failure step=1 command=session' "$batch_text_fail_out"; then
-  log "batch text first failure summary missing"
+batch_text_fail_code=$?
+set -e
+if [ "$batch_text_fail_code" -eq 0 ]; then
+  log "expected text batch failure"
+  cat "$batch_text_fail_out" >&2
+  exit 1
+fi
+if ! grep -q 'ERROR BATCH_STEP_FAILED' "$batch_text_fail_out"; then
+  log "batch text failure code missing"
   cat "$batch_text_fail_out" >&2
   exit 1
 fi
@@ -616,14 +666,14 @@ set +e
 printf '%s' "$bad_semantic_batch" | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$bad_semantic_out"
 bad_semantic_code=$?
 set -e
-if [ "$bad_semantic_code" -ne 0 ]; then
-  log "command failed before producing batch failure envelope: ${CLI[*]} batch --session ${SESSION_NAME} --stdin-json"
+if [ "$bad_semantic_code" -eq 0 ]; then
+  log "expected unsupported semantic batch failure: ${CLI[*]} batch --session ${SESSION_NAME} --stdin-json"
   cat "$bad_semantic_out" >&2 || true
   exit 1
 fi
 bad_semantic_json="$bad_semantic_out"
 assert_json "$bad_semantic_json" "unsupported batch semantic flag fails" \
-  "data.ok === true && data.data.summary.failedCount === 1 && String(data.data.summary.firstFailureMessage).includes('unsupported click batch argument') && String(data.data.summary.firstFailureMessage).includes('outside batch')"
+  "data.ok === false && data.error.code === 'BATCH_STEP_FAILED' && data.error.details.summary.failedCount === 1 && String(data.error.details.summary.firstFailureMessage).includes('unsupported click batch argument') && String(data.error.details.summary.firstFailureMessage).includes('outside batch')"
 
 log "bootstrap apply"
 bootstrap_json="$(run_json bootstrap-apply bootstrap apply --session "$SESSION_NAME" --init-script ./scripts/manual/bootstrap-fixture.js --headers-file "$HEADERS_FILE")"

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -513,6 +513,7 @@ pw batch --session bug-a --file ./steps.json
 - `batch` 适合单 session 串行动作，不适合 lifecycle/auth/environment/dialog recovery。
 - batch `click` 支持 ref、`--selector`、`--text`、`--role --name`；`--text` 和 `--role` 可带 `--nth`。
 - batch `click` 不支持 `--label`/`--placeholder`/`--testid` 等完整 CLI parity；需要时拆出单命令。
+- 默认遇到首个失败会返回非零退出码和 `ok:false` / `BATCH_STEP_FAILED`；需要收集失败步骤时显式加 `--continue-on-error`。
 - 默认 text 输出是轻量摘要：step 数、成功/失败数、首个失败、warnings；不倾倒嵌套 `results`。
 - 脚本解析、字段断言、完整 envelope 消费必须加 `--output json`。
 - JSON envelope 保持 `data.summary` 和 `data.results`；只需要 JSON 汇总时加 `--summary-only`。

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -144,7 +144,7 @@ pw page current --session bug-a
 If `VERIFY_FAILED` follows an action and the page state is unexpectedly wrong, collect the compact handoff bundle:
 
 ```bash
-pw diagnostics bundle --session bug-a --limit 20
+pw diagnostics bundle --session bug-a --out .pwcli/bundles/verify-failure --limit 20
 ```
 
 Do not treat `VERIFY_FAILED` as an action failure. It means the check completed and the observed state did not match the expectation.

--- a/src/app/batch/run-batch.ts
+++ b/src/app/batch/run-batch.ts
@@ -299,7 +299,7 @@ async function executeBatchStep(tokens: string[], sessionName: string) {
         data: await managedOpen(args[0], { sessionName, reset: false }),
       };
     case "code": {
-      const source = rawStep.slice(rawStep.indexOf("code") + 4).trim();
+      const source = args.join(" ").trim();
       if (!source) {
         throw new Error(`batch step '${rawStep}' requires inline code`);
       }

--- a/src/app/commands/batch.ts
+++ b/src/app/commands/batch.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { Command } from "commander";
 import { runBatch } from "../batch/run-batch.js";
-import { printCommandResult } from "../output.js";
+import { printCommandError, printCommandResult } from "../output.js";
 import {
   addSessionOption,
   printSessionAwareCommandError,
@@ -69,14 +69,27 @@ export function registerBatchCommand(program: Command): void {
           throw new Error("batch requires --file <path> or --stdin-json stdin input");
         }
         const commands = parseBatchCommands(input);
+        const result = await runBatch({
+          sessionName,
+          commands,
+          continueOnError: options.continueOnError,
+          includeResults: options.includeResults,
+          summaryOnly: options.summaryOnly,
+        });
+        const summary = result.summary;
+        if (!options.continueOnError && summary.failedCount > 0) {
+          printCommandError("batch", {
+            code: "BATCH_STEP_FAILED",
+            message: summary.firstFailureMessage ?? "batch step failed",
+            retryable: true,
+            suggestions: summary.firstFailureSuggestions ?? [],
+            details: result as unknown as Record<string, unknown>,
+          });
+          process.exitCode = 1;
+          return;
+        }
         printCommandResult("batch", {
-          data: await runBatch({
-            sessionName,
-            commands,
-            continueOnError: options.continueOnError,
-            includeResults: options.includeResults,
-            summaryOnly: options.summaryOnly,
-          }),
+          data: result,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : "batch failed";

--- a/src/app/commands/click.ts
+++ b/src/app/commands/click.ts
@@ -7,6 +7,14 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 export function registerClickCommand(program: Command): void {
   addSessionOption(
     program
@@ -35,7 +43,7 @@ export function registerClickCommand(program: Command): void {
         return;
       }
 
-      const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
+      const nth = parseNth(options.nth);
       if (options.role) {
         printCommandResult(
           "click",

--- a/src/app/commands/fill.ts
+++ b/src/app/commands/fill.ts
@@ -19,8 +19,16 @@ type FillOptions = {
   nth?: string;
 };
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 function buildSemanticTarget(options: FillOptions) {
-  const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
+  const nth = parseNth(options.nth);
   if (options.role) {
     return {
       kind: "role" as const,

--- a/src/app/commands/type.ts
+++ b/src/app/commands/type.ts
@@ -19,8 +19,16 @@ type TypeOptions = {
   nth?: string;
 };
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 function buildSemanticTarget(options: TypeOptions) {
-  const nth = Math.max(1, options.nth ? Number(options.nth) : 1);
+  const nth = parseNth(options.nth);
   if (options.role) {
     return {
       kind: "role" as const,

--- a/src/infra/playwright/cli-client.ts
+++ b/src/infra/playwright/cli-client.ts
@@ -288,16 +288,53 @@ export async function runManagedSessionCommand(
     persistent?: boolean;
     endpoint?: string;
     createIfMissing?: boolean;
+    timeoutMs?: number;
+    timeoutMessage?: string;
+    timeoutCode?: string;
   },
 ) {
   const { clientInfo, sessionName, session } = await ensureManagedSession(options);
-  const text = await session.run(clientInfo, {
+  const run = session.run(clientInfo, {
     ...args,
   });
+  const text = options?.timeoutMs
+    ? await withManagedSessionTimeout(run, {
+        timeoutMs: options.timeoutMs,
+        timeoutMessage: options.timeoutMessage,
+        timeoutCode: options.timeoutCode,
+      })
+    : await run;
   return {
     sessionName,
     text: text.text,
   };
+}
+
+async function withManagedSessionTimeout<T>(
+  operation: Promise<T>,
+  options: {
+    timeoutMs: number;
+    timeoutMessage?: string;
+    timeoutCode?: string;
+  },
+) {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          const code = options.timeoutCode ?? "MANAGED_COMMAND_TIMEOUT";
+          const message = options.timeoutMessage ?? "managed session command timed out";
+          reject(new Error(`${code}:${message}`));
+        }, options.timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export async function stopManagedSession(sessionName?: string) {

--- a/src/infra/playwright/runtime/environment.ts
+++ b/src/infra/playwright/runtime/environment.ts
@@ -1,7 +1,4 @@
-import { createRequire } from "node:module";
-import type { Socket } from "node:net";
-import { dirname, join } from "node:path";
-import { ensureManagedSession } from "../cli-client.js";
+import { runManagedSessionCommand } from "../cli-client.js";
 import {
   parseErrorText,
   parseJsonStringLiteral,
@@ -28,27 +25,6 @@ type ManagedEnvironmentRunCodeResult = {
   };
 };
 
-type SessionLike = {
-  name: string;
-  isCompatible(clientInfo: unknown): boolean;
-  _connect(): Promise<{ socket?: Socket; error?: Error }>;
-};
-
-const require = createRequire(import.meta.url);
-const playwrightCoreRoot = dirname(require.resolve("playwright-core/package.json"));
-const socketConnectionModule = require(
-  join(playwrightCoreRoot, "lib/tools/utils/socketConnection.js"),
-);
-const { SocketConnection } = socketConnectionModule as {
-  SocketConnection: new (
-    socket: Socket,
-  ) => {
-    onmessage?: (message: { id?: number; result?: { text?: string }; error?: string }) => void;
-    onclose?: () => void;
-    send(message: Record<string, unknown>): Promise<void>;
-    close(): void;
-  };
-};
 const ENVIRONMENT_TIMEOUT_MS = 4000;
 
 function environmentSessionResult(
@@ -86,141 +62,21 @@ function parseEnvironmentMutationResult(
   return payload as Record<string, unknown>;
 }
 
-class TimeoutSocketConnectionClient {
-  private readonly connection: {
-    onmessage?: (message: { id?: number; result?: { text?: string }; error?: string }) => void;
-    onclose?: () => void;
-    send(message: Record<string, unknown>): Promise<void>;
-    close(): void;
-  };
-
-  private nextMessageId = 1;
-
-  private readonly callbacks = new Map<
-    number,
-    {
-      resolve: (value: { text?: string }) => void;
-      reject: (error: Error) => void;
-      timer: NodeJS.Timeout;
-    }
-  >();
-
-  constructor(socket: Socket) {
-    this.connection = new SocketConnection(socket);
-    this.connection.onmessage = (message) => this.onMessage(message);
-    this.connection.onclose = () => this.rejectCallbacks(new Error("Session closed"));
-  }
-
-  async send(
-    method: string,
-    params: Record<string, unknown>,
-    timeoutMs: number,
-    timeoutMessage: string,
-  ) {
-    const messageId = this.nextMessageId++;
-    const responsePromise = new Promise<{ text?: string }>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.callbacks.delete(messageId);
-        this.connection.close();
-        reject(new Error(`ENVIRONMENT_LIMITATION:${timeoutMessage}`));
-      }, timeoutMs);
-      this.callbacks.set(messageId, { resolve, reject, timer });
-    });
-    await this.connection.send({
-      id: messageId,
-      method,
-      params,
-    });
-    return await responsePromise;
-  }
-
-  static async sendAndClose(
-    socket: Socket,
-    method: string,
-    params: Record<string, unknown>,
-    timeoutMs: number,
-    timeoutMessage: string,
-  ) {
-    const connection = new TimeoutSocketConnectionClient(socket);
-    try {
-      return await connection.send(method, params, timeoutMs, timeoutMessage);
-    } finally {
-      connection.close();
-    }
-  }
-
-  close() {
-    this.connection.close();
-  }
-
-  private onMessage(message: { id?: number; result?: { text?: string }; error?: string }) {
-    if (!message.id) {
-      throw new Error(`Unexpected message without id: ${JSON.stringify(message)}`);
-    }
-    const callback = this.callbacks.get(message.id);
-    if (!callback) {
-      throw new Error(`Unexpected message id: ${message.id}`);
-    }
-    this.callbacks.delete(message.id);
-    clearTimeout(callback.timer);
-    if (message.error) {
-      callback.reject(new Error(message.error));
-      return;
-    }
-    callback.resolve(message.result ?? {});
-  }
-
-  private rejectCallbacks(error: Error) {
-    for (const callback of this.callbacks.values()) {
-      clearTimeout(callback.timer);
-      callback.reject(error);
-    }
-    this.callbacks.clear();
-  }
-}
-
-async function runManagedEnvironmentCommand(
-  args: Record<string, unknown>,
-  options: ManagedEnvironmentOptions,
-  timeoutMessage: string,
-) {
-  const { clientInfo, sessionName, session } = await ensureManagedSession({
-    sessionName: options.sessionName,
-  });
-  const managedSession = session as unknown as SessionLike;
-  if (!managedSession.isCompatible(clientInfo)) {
-    throw new Error(
-      `ENVIRONMENT_LIMITATION:Managed session '${managedSession.name}' is not compatible with the current client runtime.`,
-    );
-  }
-  const { socket } = await managedSession._connect();
-  if (!socket) {
-    throw new Error(`SESSION_NOT_FOUND:${sessionName}`);
-  }
-  const result = await TimeoutSocketConnectionClient.sendAndClose(
-    socket,
-    "run",
-    { args, cwd: process.cwd() },
-    ENVIRONMENT_TIMEOUT_MS,
-    timeoutMessage,
-  );
-  return {
-    sessionName,
-    text: result.text ?? "",
-  };
-}
-
 async function managedEnvironmentRunCode(
   source: string,
   options: ManagedEnvironmentOptions,
   timeoutMessage: string,
 ): Promise<ManagedEnvironmentRunCodeResult> {
-  const result = await runManagedEnvironmentCommand(
+  const result = await runManagedSessionCommand(
     {
       _: ["run-code", source],
     },
-    options,
-    timeoutMessage,
+    {
+      sessionName: options.sessionName,
+      timeoutMs: ENVIRONMENT_TIMEOUT_MS,
+      timeoutMessage,
+      timeoutCode: "ENVIRONMENT_LIMITATION",
+    },
   );
   const errorText = parseErrorText(result.text);
   if (errorText) {

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -229,30 +229,40 @@ export async function managedClick(options: {
   }
 
   if (options.selector) {
-    const button = options.button ? JSON.stringify({ button: options.button }) : "undefined";
-    const result = await managedActionRunCode({
-      command: "click",
-      sessionName: options.sessionName,
-      source: `async page => {
-        await page.locator(${JSON.stringify(options.selector)}).click(${button});
-        return 'clicked';
-      }`,
-    });
+    const args = ["click", options.selector];
+    if (options.button) {
+      args.push(options.button);
+    }
+    const result = await runManagedSessionCommand(
+      {
+        _: args,
+      },
+      {
+        sessionName: options.sessionName,
+      },
+    );
+    throwIfManagedActionError(result.text, { command: "click", sessionName: options.sessionName });
 
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const run = await recordRun("click", options.sessionName, result.page, {
+    const page = parsePageSummary(result.text);
+    const run = await recordRun("click", options.sessionName, page, {
       target: { selector: options.selector },
       diagnosticsDelta,
     });
     return {
-      session: result.session,
-      page: result.page,
+      session: {
+        scope: "managed",
+        name: result.sessionName,
+        default: result.sessionName === "default",
+      },
+      page,
       data: {
         selector: options.selector,
         ...(options.button ? { button: options.button } : {}),
         acted: true,
         diagnosticsDelta,
         run,
+        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -421,29 +431,36 @@ export async function managedFill(options: {
   }
 
   if (options.selector) {
-    const result = await managedActionRunCode({
-      command: "fill",
-      sessionName: options.sessionName,
-      source: `async page => {
-        await page.locator(${JSON.stringify(options.selector)}).fill(${JSON.stringify(options.value)});
-        return 'filled';
-      }`,
-    });
+    const result = await runManagedSessionCommand(
+      {
+        _: ["fill", options.selector, options.value],
+      },
+      {
+        sessionName: options.sessionName,
+      },
+    );
+    throwIfManagedActionError(result.text, { command: "fill", sessionName: options.sessionName });
 
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const run = await recordRun("fill", options.sessionName, result.page, {
+    const page = parsePageSummary(result.text);
+    const run = await recordRun("fill", options.sessionName, page, {
       target: { selector: options.selector },
       diagnosticsDelta,
     });
     return {
-      session: result.session,
-      page: result.page,
+      session: {
+        scope: "managed",
+        name: result.sessionName,
+        default: result.sessionName === "default",
+      },
+      page,
       data: {
         selector: options.selector,
         value: options.value,
         filled: true,
         diagnosticsDelta,
         run,
+        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -632,33 +649,41 @@ async function managedBooleanControlAction(
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await managedActionRunCode({
-      command,
-      sessionName: options.sessionName,
-      source: `async page => {
-        await page.locator(${JSON.stringify(options.selector)}).${command}();
-        return JSON.stringify({ acted: true, checked: ${command === "check" ? "true" : "false"} });
-      }`,
-    });
+    const result = await runManagedSessionCommand(
+      {
+        _: [command, options.selector],
+      },
+      {
+        sessionName: options.sessionName,
+      },
+    );
+    throwIfManagedActionError(result.text, { command, sessionName: options.sessionName });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const run = await recordRun(command, options.sessionName, result.page, {
+    const page = parsePageSummary(result.text);
+    const run = await recordRun(command, options.sessionName, page, {
       target: { selector: options.selector },
       diagnosticsDelta,
     });
     return {
-      session: result.session,
-      page: result.page,
+      session: {
+        scope: "managed",
+        name: result.sessionName,
+        default: result.sessionName === "default",
+      },
+      page,
       data: {
         selector: options.selector,
         acted: true,
         checked: command === "check",
         diagnosticsDelta,
         run,
+        ...maybeRawOutput(result.text),
       },
     };
   }
 
   const ref = normalizeRef(options.ref ?? "");
+  await assertFreshRefEpoch({ sessionName: options.sessionName, ref });
   const result = await runManagedSessionCommand(
     {
       _: [command, ref],
@@ -712,27 +737,34 @@ export async function managedHover(options: {
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await managedActionRunCode({
-      command: "hover",
-      sessionName: options.sessionName,
-      source: `async page => {
-        await page.locator(${JSON.stringify(options.selector)}).hover();
-        return JSON.stringify({ acted: true });
-      }`,
-    });
+    const result = await runManagedSessionCommand(
+      {
+        _: ["hover", options.selector],
+      },
+      {
+        sessionName: options.sessionName,
+      },
+    );
+    throwIfManagedActionError(result.text, { command: "hover", sessionName: options.sessionName });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const run = await recordRun("hover", options.sessionName, result.page, {
+    const page = parsePageSummary(result.text);
+    const run = await recordRun("hover", options.sessionName, page, {
       target: { selector: options.selector },
       diagnosticsDelta,
     });
     return {
-      session: result.session,
-      page: result.page,
+      session: {
+        scope: "managed",
+        name: result.sessionName,
+        default: result.sessionName === "default",
+      },
+      page,
       data: {
         selector: options.selector,
         acted: true,
         diagnosticsDelta,
         run,
+        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -823,6 +855,7 @@ export async function managedSelect(options: {
   }
 
   const ref = normalizeRef(options.ref ?? "");
+  await assertFreshRefEpoch({ sessionName: options.sessionName, ref });
   const result = await runManagedSessionCommand(
     {
       _: ["select", ref, options.value],
@@ -938,6 +971,9 @@ export async function managedScreenshot(options?: {
   fullPage?: boolean;
   sessionName?: string;
 }) {
+  if (options?.ref) {
+    await assertFreshRefEpoch({ sessionName: options.sessionName, ref: normalizeRef(options.ref) });
+  }
   const run = await ensureRunDir(options?.sessionName);
   const defaultPath = join(run.runDir, `screenshot-${Date.now()}.png`);
   const target = options?.ref
@@ -1030,13 +1066,16 @@ export async function managedUpload(options: {
   files: string[];
   sessionName?: string;
 }) {
+  if (!options.ref && !options.selector) {
+    throw new Error("upload requires a ref or selector");
+  }
+  if (options.ref) {
+    await assertFreshRefEpoch({ sessionName: options.sessionName, ref: normalizeRef(options.ref) });
+  }
   const files = options.files.map((file) => JSON.stringify(resolve(file))).join(", ");
   const target = options.ref
     ? `page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.ref)}`)})`
     : `page.locator(${JSON.stringify(options.selector)})`;
-  if (!options.ref && !options.selector) {
-    throw new Error("upload requires a ref or selector");
-  }
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
   const result = await managedRunCode({
@@ -1072,16 +1111,27 @@ export async function managedDrag(options: {
   toSelector?: string;
   sessionName?: string;
 }) {
+  if ((!options.fromRef && !options.fromSelector) || (!options.toRef && !options.toSelector)) {
+    throw new Error("drag requires source and target");
+  }
+  if (options.fromRef) {
+    await assertFreshRefEpoch({
+      sessionName: options.sessionName,
+      ref: normalizeRef(options.fromRef),
+    });
+  }
+  if (options.toRef) {
+    await assertFreshRefEpoch({
+      sessionName: options.sessionName,
+      ref: normalizeRef(options.toRef),
+    });
+  }
   const source = options.fromRef
     ? `page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.fromRef)}`)})`
     : `page.locator(${JSON.stringify(options.fromSelector)})`;
   const target = options.toRef
     ? `page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.toRef)}`)})`
     : `page.locator(${JSON.stringify(options.toSelector)})`;
-
-  if ((!options.fromRef && !options.fromSelector) || (!options.toRef && !options.toSelector)) {
-    throw new Error("drag requires source and target");
-  }
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
   const result = await managedRunCode({
@@ -1122,6 +1172,9 @@ export async function managedDownload(options: {
 }) {
   if (!options.ref && !options.selector) {
     throw new Error("download requires a ref or selector");
+  }
+  if (options.ref) {
+    await assertFreshRefEpoch({ sessionName: options.sessionName, ref: normalizeRef(options.ref) });
   }
   const target = options.ref
     ? `page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.ref)}`)})`

--- a/src/infra/playwright/runtime/state-checks.ts
+++ b/src/infra/playwright/runtime/state-checks.ts
@@ -65,7 +65,7 @@ function targetExpression(target: StateTarget) {
     }
     return `page.getByTestId(${JSON.stringify(target.testid)})`;
   })();
-  return nth > 1 ? `${locator}.nth(${nth - 1})` : locator;
+  return `${locator}.nth(${nth - 1})`;
 }
 
 function targetBaseExpression(target: StateTarget) {
@@ -189,7 +189,7 @@ export async function managedIsState(options: {
   const result = await managedRunCode({
     sessionName: options.sessionName,
     source: `async page => {
-      const locator = ${targetExpression(options.target)}.first();
+      const locator = ${targetExpression(options.target)};
       const baseLocator = ${targetBaseExpression(options.target)};
       const count = await baseLocator.count();
       if (count === 0) {
@@ -228,13 +228,13 @@ function verifySuggestions(assertion: VerifyAssertion): string[] {
     return [
       "Run `pw read-text --session <name> --include-overlay --max-chars 4000` to inspect visible text",
       "Run `pw locate --session <name> --text '<text>'` to inspect text candidates",
-      "Run `pw diagnostics bundle --session <name> --limit 20` if the missing text follows an action",
+      "Run `pw diagnostics bundle --session <name> --out .pwcli/bundles/verify-failure --limit 20` if the missing text follows an action",
     ];
   }
   return [
     "Run `pw locate --session <name> --selector '<selector>'` to inspect candidates",
     "Run `pw snapshot -i --session <name>` when you need fresh refs",
-    "Run `pw diagnostics bundle --session <name> --limit 20` if the failed assertion follows an action",
+    "Run `pw diagnostics bundle --session <name> --out .pwcli/bundles/verify-failure --limit 20` if the failed assertion follows an action",
   ];
 }
 

--- a/src/infra/playwright/runtime/workspace.ts
+++ b/src/infra/playwright/runtime/workspace.ts
@@ -6,11 +6,6 @@ import { DIAGNOSTICS_STATE_KEY, maybeRawOutput } from "./shared.js";
 type WorkspacePage = {
   index: number;
   pageId: string;
-  navigationId?: string;
-  url?: string;
-  title?: string;
-  current?: boolean;
-  openerPageId?: string | null;
 };
 
 export async function managedWorkspaceProjection(options?: { sessionName?: string }) {


### PR DESCRIPTION
## 背景

本 PR 聚焦于 **core convergence contract 收敛**，目标是统一 pwcli 在以下维度的行为语义：

- ref / snapshot epoch 一致性约束
- batch 执行语义与错误模型
- verify / state-check 与 mutation 的职责边界
- CLI 行为与 runtime contract 的对齐

---

## 主要变更

### 1. Ref & Snapshot Contract 收紧

- 所有 **ref-backed mutation / evidence 操作**统一要求：
  - 必须基于最新 snapshot epoch
  - 任一条件变化（navigation / page switch / missing ref） → `REF_STALE`
- 覆盖范围从原先的：
  - `click / fill / type`
- 扩展为：
  - `hover / check / uncheck / select / upload / drag / download / screenshot`

👉 目标：彻底消除“部分命令宽松、部分严格”的不一致行为。

---

### 2. Batch 语义重构

- 默认行为：
  - 首个失败即：
    - exit code ≠ 0
    - 返回 `BATCH_STEP_FAILED`
- 新增/明确：
  - `--continue-on-error` → 收集所有步骤结果
  - `--include-results` → 控制结果展开
  - `--summary-only` → 只输出 summary

- error envelope：
  - `error.details.summary` 与 success path 对齐
  - 保证机器可消费一致性

- text 输出：
  - 默认仅 summary（不展开 results）

---

### 3. Verify 语义明确化

- `verify`：
  - 明确为 **断言检查（assertion）**，不是 action
  - failure → `VERIFY_FAILED`（但不是执行失败）
- 返回结构：
  - `{ assertion, passed, retryable, suggestions }`

👉 避免 verify 被误当成 control flow/action。

---

### 4. CLI 参数语义收紧（nth）

- `--nth`：
  - 统一为 **必须为正整数**
  - 非法输入直接抛错（如 `"nope"`）
- 应用于：
  - `click / fill / type`

---

### 5. Managed Session Timeout 支持

- `runManagedSessionCommand` 增加：
  - `timeoutMs`
  - `timeoutMessage`
  - `timeoutCode`
- 实现：
  - Promise.race + 显式 timeout error

👉 解决长时间挂起不可控问题。

---

### 6. Environment 层简化

- 移除自实现 socket + timeout client
- 统一收敛到 cli-client 层 timeout 控制

👉 减少重复抽象，收敛 runtime responsibility。

---

### 7. Smoke Tests 强化

新增覆盖：

- REF_STALE：
  - hover / screenshot / check / select / upload / drag / download
- verify：
  - success / failure / suggestion
- batch：
  - failure summary
  - continue-on-error
  - text vs json 行为
- 非法语义参数（如 nth）

👉 保证 contract 行为在 CLI 层可回归。

---

## 设计结论（关键）

- **ref = snapshot scoped capability（非稳定 ID）**
- **verify ≠ action**
- **batch = execution container（非 lifecycle manager）**
- **CLI ≈ contract surface（而不是宽松 wrapper）**

---

## 风险与影响

- 更严格的参数校验（可能破坏历史宽松用法）
- ref 使用错误将更频繁暴露为 `REF_STALE`
- batch 默认失败策略更明确（需要使用 `--continue-on-error` 才能收集结果）

---

## 后续

- verify 扩展（issue #23）
- batch 能力按真实场景增量扩展（不追求 parity）
- 更完整 diagnostics / recovery 流程

---

## Checklist

- [x] contract 行为统一
- [x] CLI / runtime 对齐
- [x] smoke tests 覆盖关键路径
- [x] 文档同步更新