### PR TITLE
Fix agent recovery and command ergonomics

### DIFF
--- a/.codex/auth-provider-authoring.md
+++ b/.codex/auth-provider-authoring.md
@@ -17,6 +17,7 @@ pw auth <provider> --session <name> --arg key=value
   -> src/app/commands/auth.ts
   -> src/infra/auth-providers/registry.ts
   -> managedRunCode(page => provider(page, args))
+  -> output provider/pageState/resolved target fields, not raw provider args
 ```
 
 ## 硬边界
@@ -62,6 +63,7 @@ async (page, args) => {
 - `ok`
 - `pageState.url`
 - `pageState.title`
+- `resolvedTargetUrl` / `resolvedBy`（如果 provider 会解析业务目标）
 - 能证明登录结果的低敏字段
 
 禁止返回：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 4. 改代码
 5. 同步 skill
 6. 同步 architecture docs（如果边界、限制、扩展方向有变化）
-7. 跑 typecheck/build/smoke
+7. 做受影响的最小验证；最终发布/总验收才跑全量 smoke
 ```
 
 ## 结构
@@ -63,13 +63,19 @@ docs/
 
 ## 验证
 
-优先跑：
+日常改动优先：
 
 ```bash
-pnpm typecheck
 pnpm build
-pnpm smoke
+pw <affected-command> ...
 ```
+
+规则：
+
+- alias 已经是 `pw`；构建后直接用 `pw` 做真实、针对性的命令验证。
+- 不默认跑 `pnpm smoke` / 全量 gate。
+- 最终发布、合并前总验收，或用户明确要求时，才跑全量测试。
+- 类型风险明显时再补 `pnpm typecheck`。
 
 ## Review guidelines
 

--- a/docs/architecture/domain-status.md
+++ b/docs/architecture/domain-status.md
@@ -23,6 +23,7 @@
   - trace
   - diagnostics records
   - run artifacts
+- same-session managed command dispatch uses a per-session lock before entering the Playwright substrate; lock timeout reports recoverable `SESSION_BUSY`
 
 ### 当前限制
 
@@ -75,6 +76,7 @@
 - `snapshot` records the latest ref epoch for the active page/navigation identity
 - ref-backed `click` / `fill` / `type` validate against the latest snapshot epoch before reporting success
 - `locate|get|is` state-check primitives for compact read-only target checks
+- `upload` best-effort waits for input file count plus `change` / `input` settle, and returns `nextSteps` when page-level acceptance still needs verification
 
 ### 当前限制
 
@@ -100,14 +102,14 @@
 - `storage local|session` read + current-origin `get|set|delete|clear`
 - `profile inspect`
 - `auth` 内置 provider 执行 + `save-state`
-- `dc` 是内置 DC/Forge auth provider；默认手机号和验证码内聚在 provider 内，传了 `targetUrl` 就使用指定业务 URL，未传 URL 时执行默认登录流程
+- `dc` 是内置 DC/Forge auth provider；默认手机号和验证码内聚在 provider 内，目标解析顺序为显式 `targetUrl`、当前 Forge 页面、默认本地 Forge
 - `fixture-auth` 是内部 contract 测试 provider，用于 smoke 验证 auth 执行链
 
 ### 当前限制
 
 - `storage local|session get|set|delete|clear` 只作用于当前页 origin，不做跨 origin storage 编辑
 - `auth` 不负责 session shape
-- `dc` 不接受 `instance` 参数；不暴露环境参数，RND 固定入口由 skill 引导 agent 显式打开
+- `dc` 不接受 `instance` 参数；不暴露环境参数，用户给具体业务 URL 时由 skill 作为 `targetUrl` 传入
 - `profile open` 已移除
 - 当前没有外部 plugin 加载、安装、发现、生命周期机制
 

--- a/scripts/manual/upload-drag-download.js
+++ b/scripts/manual/upload-drag-download.js
@@ -2,8 +2,13 @@ async (page) => {
   await page.setContent(`
     <input id="f" type="file">
     <div id="name"></div>
+    <div id="events" data-change="0" data-input="0"></div>
     <script>
+      document.getElementById('f').addEventListener('input', () => {
+        document.getElementById('events').dataset.input = String(Number(document.getElementById('events').dataset.input) + 1);
+      });
       document.getElementById('f').addEventListener('change', e => {
+        document.getElementById('events').dataset.change = String(Number(document.getElementById('events').dataset.change) + 1);
         document.getElementById('name').textContent = e.target.files[0]?.name || '';
       });
     </script>

--- a/scripts/smoke/pwcli-smoke.sh
+++ b/scripts/smoke/pwcli-smoke.sh
@@ -466,7 +466,7 @@ assert_json "$auth_info_json" "auth info exposes fixture-auth contract" \
   "data.ok === true && data.data.name === 'fixture-auth' && data.data.args.some(item => item.name === 'marker')"
 auth_apply_json="$(run_json auth-apply auth fixture-auth --session "$SESSION_NAME" --arg marker=smoke-auth --save-state "$AUTH_STATE_FILE")"
 assert_json "$auth_apply_json" "auth provider executes and saves state" \
-  "data.ok === true && data.data.provider === 'fixture-auth' && data.data.pageState.authMarker === 'smoke-auth' && data.data.stateSaved === '${AUTH_STATE_FILE}'"
+  "data.ok === true && data.data.provider === 'fixture-auth' && !('args' in data.data) && data.data.pageState.authMarker === 'smoke-auth' && data.data.stateSaved === '${AUTH_STATE_FILE}'"
 storage_after_auth_json="$(run_json storage-after-auth storage local --session "$SESSION_NAME")"
 assert_json "$storage_after_auth_json" "auth provider writes local storage marker" \
   "data.ok === true && data.data.entries['pwcli-auth-marker'] === 'smoke-auth'"

--- a/scripts/test/diagnostics-failure-run.test.ts
+++ b/scripts/test/diagnostics-failure-run.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import {
+  buildDiagnosticsAuditConclusion,
+  managedDiagnosticsDigest,
+} from "../../src/domain/diagnostics/service.js";
+
+const cwd = process.cwd();
+const tempDir = await mkdtemp(join(tmpdir(), "pwcli-diagnostics-failure-"));
+
+try {
+  process.chdir(tempDir);
+
+  const runId = "2026-04-30T00-00-00-000Z-bug-a";
+  const runDir = join(tempDir, ".pwcli", "runs", runId);
+  await mkdir(runDir, { recursive: true });
+  await writeFile(
+    join(runDir, "events.jsonl"),
+    `${JSON.stringify({
+      ts: "2026-04-30T00:00:00.000Z",
+      command: "wait",
+      sessionName: "bug-a",
+      failed: true,
+      status: "failed",
+      condition: { kind: "selector", selector: ".missing" },
+      diagnosticsDelta: { unavailable: true, reason: "MODAL_STATE_BLOCKED" },
+      failure: {
+        code: "WAIT_FAILED",
+        message: "Timeout 30000ms exceeded",
+        retryable: null,
+        suggestions: [],
+        details: null,
+      },
+    })}\n${JSON.stringify({
+      ts: "2026-04-30T00:00:01.000Z",
+      command: "click",
+      sessionName: "bug-a",
+      status: "dialog-pending",
+      acted: true,
+      modalPending: true,
+      diagnosticsDelta: { unavailable: true, reason: "MODAL_STATE_BLOCKED" },
+      failureSignal: {
+        code: "MODAL_STATE_BLOCKED",
+        message: "action fired and a browser dialog is pending",
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const digest = await managedDiagnosticsDigest({ runId, limit: 10 });
+  assert.equal(digest.data.summary.failureCount, 1);
+  assert.equal(digest.data.summary.dialogPendingCount, 1);
+  assert.ok(
+    digest.data.topSignals.some(
+      (signal: { kind: string }) => signal.kind === "failure:MODAL_STATE_BLOCKED",
+    ),
+  );
+
+  const audit = buildDiagnosticsAuditConclusion({
+    sessionName: "bug-a",
+    latestRunId: runId,
+    limit: 10,
+    digestData: { summary: {}, topSignals: [] },
+    latestRunEvents: {
+      runId,
+      events: [
+        {
+          ts: "2026-04-30T00:00:01.000Z",
+          command: "click",
+          failureSignal: {
+            code: "MODAL_STATE_BLOCKED",
+            message: "action fired and a browser dialog is pending",
+          },
+        },
+      ],
+    },
+  });
+  assert.equal(audit.status, "failed_or_risky");
+  assert.equal(audit.failureKind, "MODAL_STATE_BLOCKED");
+} finally {
+  process.chdir(cwd);
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -28,6 +28,7 @@ description: "Use pwcli for browser automation, page exploration, diagnostics, s
 - `auth` 只执行内置 auth provider，不负责创建 session；没有外部 plugin 机制。
 - 所有浏览器命令显式带 session，实战优先 `-s <name>`，解释 contract 时用 `--session <name>`。
 - session 名最长 16 字符，只用字母、数字、`-`、`_`。
+- 同一个 session 的命令按 per-session lock 串行进入 Playwright；依赖步骤仍按顺序写，不要在外层并发发同一 session 的动作。
 - 默认 stdout 给 Agent 阅读；脚本解析和字段断言才用 `--output json`。
 
 ## 命令风格
@@ -152,18 +153,29 @@ pw verify text -s bug-a --text '保存成功'
 - `page current`：当前 page projection。
 - `read-text`：可见文本，适合快速理解页面。
 - `read-text --include-overlay`：点击 dropdown/modal/popover 后读取浮层文本。
-- `locate/get/is`：窄状态检查；只返回候选、事实或布尔值，不生成动作计划。
+- `locate/get/is`：窄状态检查；`locate` 返回总匹配数和候选 metadata，`get/is` 返回事实或布尔值，不生成动作计划。
 - `verify`：动作和 wait 之后的 read-only 断言；通过/失败都给 Agent 可消费结果，失败返回 `VERIFY_FAILED`。
 - `snapshot -i`：只看可交互节点，找 ref 首选。
 - `snapshot`：完整结构树，需要理解页面层级时再用。
 
-`locate/get/is/verify` 适合脚本断言和低噪声状态读取。需要 fresh ref 或页面结构时继续用 `snapshot -i`；不要把这些命令当 action planner。
+`locate/get/is/verify` 适合脚本断言和低噪声状态读取。`locate` 的 `count` 是总匹配数，候选最多展示前 10 个；根据 `href`、`role/name`、`region`、`ancestor`、`selectorHint` 决定下一步 selector 或语义 locator。需要 fresh ref 或页面结构时继续用 `snapshot -i`；不要把这些命令当 action planner。
 
 需要 ref 点击或结构定位：
 
 ```bash
 pw snapshot -i -s bug-a
 ```
+
+大页面不要直接全量 snapshot。先缩小范围：
+
+```bash
+pw read-text -s bug-a --selector '<main-or-panel>' --max-chars 2000
+pw locate -s bug-a --selector '<candidate-selector>'
+pw snapshot -i -s bug-a
+pw snapshot -c -s bug-a
+```
+
+只有 compact / interactive / scoped 结果不够、且确实需要完整层级时，才跑全量 `pw snapshot -s bug-a`。如果当前命令面暴露 depth 参数，优先用 depth 限制层级，不把全量 snapshot 当默认观察路径。
 
 截图证据：
 
@@ -230,9 +242,13 @@ pw diagnostics digest -s bug-a
 
 ```bash
 pw upload -s bug-a --selector 'input[type=file]' ./fixture.png
+pw wait -s bug-a --selector '.upload-ready'
+pw verify text -s bug-a --text '上传成功'
 pw download -s bug-a --selector 'a.download' --dir ./downloads
 pw download e42 -s bug-a --path ./downloads/report.csv
 ```
+
+`upload` 返回前会 best-effort 等待 input files/change settle。输出出现 `Next steps` 时，说明页面接收态无法完全判定，按提示补 `wait` / `verify` 后再继续。
 
 响应式检查：
 
@@ -300,6 +316,15 @@ pw wait network-idle -s bug-a
 pw diagnostics digest -s bug-a
 ```
 
+如果 action / wait 失败，先查最近 run；失败事件会进入 diagnostics：
+
+```bash
+pw diagnostics runs --session bug-a --limit 5
+pw diagnostics digest --run <runId>
+```
+
+如果 click 返回 `modalPending=true` / `blockedState=MODAL_STATE_BLOCKED`，表示动作已触发 alert/confirm/prompt，先 `pw dialog accept|dismiss -s bug-a`，不要把它当成普通点击失败重试。
+
 查具体接口：
 
 ```bash
@@ -320,7 +345,7 @@ pw diagnostics bundle -s bug-a --out ./bundle-bug-a --limit 20
 回放 run：
 
 ```bash
-pw diagnostics runs -s bug-a --limit 20
+pw diagnostics runs --session bug-a --limit 20
 pw diagnostics show --run <runId> --command click --limit 10
 pw diagnostics grep --run <runId> --text 'CHECKOUT_TIMEOUT' --limit 10
 ```
@@ -332,14 +357,14 @@ Trace / HAR：
 ```bash
 pw trace start -s bug-a
 pw trace stop -s bug-a
-pw trace inspect .pwcli/playwright/traces/trace.zip --section actions
-pw trace inspect .pwcli/playwright/traces/trace.zip --section requests --failed
-pw trace inspect .pwcli/playwright/traces/trace.zip --section console --level error
+pw trace inspect <traceArtifactPath> --section actions
+pw trace inspect <traceArtifactPath> --section requests --failed
+pw trace inspect <traceArtifactPath> --section console --level error
 pw har start ./bug.har -s bug-a
 pw har stop -s bug-a
 ```
 
-`trace inspect` 是离线 trace zip 查询，适合回看 actions / requests / console / errors；它不替代 live `network` / `console` / `diagnostics export`。
+`trace stop` 会输出 `traceArtifactPath` 和 inspect next step。`trace inspect` 是离线 trace artifact 查询，适合回看 actions / requests / console / errors；它不替代 live `network` / `console` / `diagnostics export`。
 
 HAR 热录制当前只暴露 substrate 边界，稳定诊断仍优先 `network` 和 `diagnostics export`。
 
@@ -391,6 +416,31 @@ pw auth <provider> -s auth-a --save-state ./auth.json
 - provider 失败时，按错误信息补参数后重试。
 
 专项 provider 细节不写进主 skill；遇到 provider-specific 失败或参数不确定时，查对应 reference。
+
+Forge / DC / DC2 / 开发者后台：
+
+```text
+if 用户给了具体 Forge/DC URL:
+  pw session create dc-main
+  pw auth dc -s dc-main --arg targetUrl='<url>'
+elif 已有 session 当前页就是 Forge/DC:
+  pw auth dc -s <session>
+else:
+  pw session create dc-main
+  pw auth dc -s dc-main
+
+pw read-text -s dc-main --max-chars 1200
+pw observe status -s dc-main
+```
+
+规则：
+
+- 看到 Forge / DC / DC2 / 开发者后台 / developer console，优先走 `pw auth dc`。
+- 不要求先 `open` Forge 页面；`auth dc` 会解析目标并导航登录。
+- 用户给了 URL 时，把 URL 作为 `--arg targetUrl=<url>` 传给 provider。
+- 用户没给 URL 时，让 provider 使用默认本地 Forge。
+- 不要手填登录表单，不要把 `dc2` 当 `instance`。
+- Forge/DC 登录失败再查 `references/forge-dc-auth.md`。
 
 ## 9. 状态复用
 

--- a/skills/pwcli/references/command-reference-advanced.md
+++ b/skills/pwcli/references/command-reference-advanced.md
@@ -63,7 +63,8 @@
 
 - 默认 `phone=19545672859`、`smsCode=000000`
 - `--arg phone=<number>`、`--arg smsCode=<code>`、`--arg targetUrl=<url>`、`--arg baseURL=<origin>`
-- 传 `targetUrl` 则使用指定业务 URL；不支持 `instance`
+- 传 `targetUrl` 则使用指定业务 URL；未传时优先用当前 Forge 页面，最后回退默认本地 Forge；不支持 `instance`
+- auth 输出给 Agent 的主字段是 `provider`、`resolvedTargetUrl`、`resolvedBy`、`pageState`，不输出原始 provider args
 
 ## Bootstrap
 

--- a/skills/pwcli/references/command-reference-diagnostics.md
+++ b/skills/pwcli/references/command-reference-diagnostics.md
@@ -55,11 +55,13 @@ state / auth / batch 命令见 `command-reference-advanced.md`。
 - 列出 `.pwcli/runs/` 下的 run 摘要
 - `--limit <n>`、`--session <name>`、`--since <iso>`（按 `lastTimestamp` 过滤）
 - 返回字段：`runId` / `sessionName` / `firstTimestamp` / `lastTimestamp` / `commandCount` / `summary`
+- `summary.failureCount` 统计失败 action/wait run event；`summary.dialogPendingCount` 统计 action fired + dialog pending
 - pwcli 启动的新 session 会把 Playwright 原始附件写入 `.pwcli/playwright/`；已有 session 需要 recreate 才切换
 
 ### `pw diagnostics show --run <runId>`
 
 - `--command <name>`、`--since <iso>`、`--fields <list>`、`--limit <n>`
+- action/wait 失败事件包含 `status=failed`、`failure`、`diagnosticsDelta`；dialog-triggering action 包含 `status=dialog-pending`、`modalPending=true`、`failureSignal.code=MODAL_STATE_BLOCKED`
 
 ### `pw diagnostics grep --run <runId> --text <substring>`
 
@@ -100,13 +102,14 @@ state / auth / batch 命令见 `command-reference-advanced.md`。
 ### `pw trace start|stop --session <name>`
 
 - 管理 trace recording
+- `trace stop` 输出 `traceArtifactPath`，并给出可直接继续执行的 `pw trace inspect <traceArtifactPath> --section actions` next step
 
-### `pw trace inspect <trace.zip> --section <section>`
+### `pw trace inspect <traceArtifactPath> --section <section>`
 
 - `--section actions|requests|console|errors`
 - `--failed`：只对 `--section requests` 传给 Playwright trace CLI
 - `--level <level>`：只对 `--section console` 生效；当前 Playwright trace CLI 可稳定映射 `error` / `warning`，其他 level 会在输出里保留 `TRACE_CONSOLE_LEVEL_FILTER_LIMITED`
-- 输出来自 Playwright bundled trace CLI，pwcli 只做薄封装和 50000 字符上限裁剪，不手工解析 trace zip
+- 输出来自 Playwright bundled trace CLI，pwcli 只做薄封装和 50000 字符上限裁剪，不手工解析 trace artifact
 - trace CLI/path/file 不可用时返回显式 `TRACE_*` 错误码
 
 边界：

--- a/skills/pwcli/references/command-reference.md
+++ b/skills/pwcli/references/command-reference.md
@@ -9,7 +9,9 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 
 ## 通用 contract
 
-**session 规则**：最大 16 字符，允许 `[a-zA-Z0-9_-]`。错误码：`SESSION_REQUIRED` / `SESSION_NAME_TOO_LONG` / `SESSION_NAME_INVALID`。
+**session 规则**：最大 16 字符，允许 `[a-zA-Z0-9_-]`。错误码：`SESSION_REQUIRED` / `SESSION_NAME_TOO_LONG` / `SESSION_NAME_INVALID` / `SESSION_BUSY`。
+
+**同 session 串行化**：同一个 session 上的 managed command 会用 per-session lock 串行进入 Playwright substrate；如果等待锁超时，返回可重试的 `SESSION_BUSY`。依赖步骤仍然按顺序发，稳定子集可用 `pw batch --session <name>`。
 
 **输出模式**：默认 agent-readable text。脚本解析加 `--output json`，envelope 为 `{ ok, command, session, page, data }` / `{ ok, command, error: { code, message, retryable, suggestions } }`。
 
@@ -73,7 +75,16 @@ state / auth / batch / environment 命令见 `command-reference-advanced.md`。
 
 ### `pw locate --session <name>`
 
-低噪声定位，返回 `count` 和最多 10 个候选摘要；不返回 ref，不生成动作计划。
+低噪声定位，返回总匹配数 `count` 和最多 10 个候选摘要；不返回 ref，不生成动作计划。
+
+候选 metadata：
+
+- `index`：1-based candidate index；传 `--nth <n>` 时仍保留总 `count`，候选只返回该 index。
+- `text` / `tagName` / `visible`
+- `href`：候选或最近链接祖先的绝对 URL，适合导航目标判断。
+- `role` / `name`：显式或常见隐式 role，以及可消费 name hint。
+- `region` / `ancestor`：最近 landmark/区域和父级摘要，帮助区分重复文本。
+- `selectorHint`：best-effort CSS 路径提示；可作为下一步 selector 起点，但不是稳定契约。
 
 目标（一次只传一个）：
 
@@ -135,6 +146,8 @@ Use `locate/get/is/verify` for narrow state checks. Use `snapshot -i` when you n
 - `-i, --interactive`：只输出可交互节点（找 ref 首选）
 - `-c, --compact`：移除低信号结构节点
 
+大页面顺序：先 `read-text --selector ... --max-chars ...` 或 `locate` 缩小范围，再 `snapshot -i` / `snapshot -c`，最后才跑全量 `snapshot`。如果当前命令面暴露 depth 参数，优先用 depth 限制层级；不要默认倾倒全量结构树。
+
 ### `pw screenshot [ref] --session <name>`
 
 - `--selector <selector>`、`--path <path>`、`--full-page`
@@ -155,17 +168,23 @@ Use `locate/get/is/verify` for narrow state checks. Use `snapshot -i` when you n
 
 定位：aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
 
+`--nth` 对 selector 和语义定位都生效；多匹配 selector 会先应用 `.nth(n-1)` 再执行 click，不触发 Playwright strict-mode 多匹配。
+
 所有 click 定位方式都会记录 action evidence：`target`、`diagnosticsDelta`、`run`。需要追踪动作后信号时用 `diagnostics runs/show/grep` 查对应 run。
 
 ### `pw fill [parts...] --session <name>`
 
 定位：aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
 
+`--nth` 对 selector 和语义定位都生效；多匹配 selector 会先应用 `.nth(n-1)` 再填值。
+
 有 `--selector` 或语义定位参数时，所有 `parts` 拼成填充值；否则第一个 part 是 ref，后续 parts 拼成填充值。
 
 ### `pw type [parts...] --session <name>`
 
 定位：focused element / aria ref / `--selector` / `--role <role> --name <name>` / `--text` / `--label` / `--placeholder` / `--testid`；附加 `--nth <n>`（1-based）
+
+`--nth` 对 selector 和语义定位都生效；多匹配 selector 会先应用 `.nth(n-1)` 再输入。
 
 无 `--selector` 和语义定位时：单个 part 输入到当前 focused element；多个 parts 时第一个 part 是 ref，后续 parts 拼成输入值。有 `--selector` 或语义定位参数时，所有 `parts` 拼成输入值。
 
@@ -174,17 +193,20 @@ Use `locate/get/is/verify` for narrow state checks. Use `snapshot -i` when you n
 ### `pw hover [ref] --session <name>`
 
 - `--selector <selector>`
+- `--nth <n>`：selector 多匹配时的 1-based 目标序号
 - 支持 hover 触发的 menu / popover / tooltip；输出复用 action evidence：`target`、`diagnosticsDelta`、`run`
 - hover 后需要读取浮层时，用 `pw read-text --session <name> --include-overlay`
 
 ### `pw check [ref] --session <name>`
 
 - `--selector <selector>`
+- `--nth <n>`：selector 多匹配时的 1-based 目标序号
 - 支持 checkbox / radio；输出复用 action evidence：`diagnosticsDelta`、`run`
 
 ### `pw uncheck [ref] --session <name>`
 
 - `--selector <selector>`
+- `--nth <n>`：selector 多匹配时的 1-based 目标序号
 - 支持 checkbox；输出复用 action evidence：`diagnosticsDelta`、`run`
 
 ### `pw select [ref] <value> --session <name>`
@@ -201,10 +223,13 @@ Use `locate/get/is/verify` for narrow state checks. Use `snapshot -i` when you n
 ### `pw upload [parts...] --session <name>`
 
 - `--selector <selector>`
+- 返回前 best-effort 等待 input `files` 数量和 `change` / `input` 事件 settle
+- 如果无法完全判定页面已接收上传，输出 `nextSteps`，按提示补 `pw wait` / `pw verify` / `pw get` 后再继续
 
 ### `pw download [ref] --session <name>`
 
-- `--selector <selector>`、`--path <path>`、`--dir <dir>`
+- `--selector <selector>`、`--path <path>`、`--dir <dir>`、`--download-dir <dir>`
+- `--download-dir` 是 `--dir` alias；不能和 `--dir` 同时使用；`--path` 不能和任一目录参数同时使用
 
 ### `pw resize --session <name>`
 

--- a/skills/pwcli/references/failure-recovery.md
+++ b/skills/pwcli/references/failure-recovery.md
@@ -28,6 +28,22 @@ pw session list
 pw session create bug-a --open 'https://example.com'
 ```
 
+### `SESSION_BUSY`
+
+Meaning:
+
+- another command is still running on the same session
+- pwcli queued for the per-session lock but timed out before dispatching to Playwright
+
+Recovery:
+
+```bash
+pw session status bug-a
+pw wait --session bug-a --selector '<expected-ready-state>'
+```
+
+Then retry the original command. Keep dependent steps sequential, or put stable same-session steps in `pw batch --session <name>`.
+
 ## Dashboard launch failures
 
 ### `DASHBOARD_UNAVAILABLE`
@@ -107,6 +123,39 @@ Modal and browser-dialog blockage is currently reported through `MODAL_STATE_BLO
 
 These codes do not auto-heal selectors and do not pick among candidates. They tell the Agent which next command to run.
 
+Failed `click` / `wait` attempts are recorded as run events. After a failed action or wait, use the run id from the error details when present, or list recent runs:
+
+```bash
+pw diagnostics runs --session bug-a --limit 5
+pw diagnostics digest --run '<runId>'
+pw diagnostics show --run '<runId>' --limit 20
+```
+
+### Dialog-triggering action pending
+
+Meaning:
+
+- a click fired successfully and triggered a browser `alert` / `confirm` / `prompt`
+- the session is now blocked by a modal dialog
+- the result is not the same as "action target not found" or "click did not happen"
+
+Typical successful action output includes:
+
+```text
+click acted=true modalPending=true
+blockedState=MODAL_STATE_BLOCKED
+```
+
+Recovery:
+
+```bash
+pw dialog accept --session bug-a
+# or
+pw dialog dismiss --session bug-a
+```
+
+Then continue with the next assertion or wait. Do not retry the original click unless the dialog was dismissed and the business flow explicitly requires another click.
+
 ### `STATE_TARGET_NOT_FOUND`
 
 Meaning:
@@ -149,6 +198,44 @@ pw diagnostics bundle --session bug-a --out .pwcli/bundles/verify-failure --limi
 
 Do not treat `VERIFY_FAILED` as an action failure. It means the check completed and the observed state did not match the expectation.
 
+## Content and challenge recovery
+
+### Content readable, diagnostics noisy
+
+Meaning:
+
+- `pw read-text` or `pw locate` confirms the target content/state
+- diagnostics contains unrelated console/network noise
+
+Recovery:
+
+1. Treat the content read as primary evidence.
+2. Keep unrelated diagnostics as background only.
+3. Escalate diagnostics only when it explains missing content, failed action, blank page, target API failure, or page error on the target flow.
+
+### Search challenge / CAPTCHA / bot challenge
+
+Meaning:
+
+- the page is a search challenge, CAPTCHA, Cloudflare challenge, or equivalent human verification screen
+- the CLI should not attempt to solve or bypass it automatically
+
+Recovery:
+
+```bash
+pw open --session bug-a '<direct-url-or-docs-url>'
+pw read-text --session bug-a --max-chars 2000
+```
+
+If a human must clear the challenge:
+
+```bash
+pw dashboard open
+pw session list --with-page
+```
+
+After human takeover, continue with `read-text`, `locate`, or `snapshot -i`. Do not encode challenge-solving steps as the automated recovery path.
+
 ### `MODAL_STATE_BLOCKED`
 
 Meaning:
@@ -188,6 +275,20 @@ pw open --session bug-a 'https://example.com/deep/path'
 ```
 
 Do not keep stacking commands on a blocked session.
+
+## Upload verification
+
+`pw upload` waits best-effort for the input file list and `change` / `input` signal before returning. Some apps accept files asynchronously through validation, hashing, or upload APIs, so a successful `uploaded=true` only means the browser input was set.
+
+If output includes `Next steps` or JSON `data.nextSteps`, continue with an app-level check:
+
+```bash
+pw wait --session bug-a --selector '<uploaded-state-selector>'
+pw verify text --session bug-a --text '上传成功'
+pw get text --session bug-a --selector '<file-name-row>'
+```
+
+If the check fails, retry `pw upload` after the page reaches the expected ready state.
 
 ## Environment limitations
 

--- a/skills/pwcli/references/forge-dc-auth.md
+++ b/skills/pwcli/references/forge-dc-auth.md
@@ -2,20 +2,47 @@
 
 本文件只讲 Forge/DC 登录细节。核心命令已写在 `SKILL.md`。
 
-## 登录步骤
+## 主路径
 
-1. 确定 Forge URL。
+本文件只处理 Forge/DC auth 的专项细节和排障。日常判断逻辑先看主 `SKILL.md`。
 
-用户给 URL，创建 session 时打开该 URL，执行 auth 时也作为 `targetUrl` 传入。
+`auth dc` 负责解析目标 URL、执行登录、把登录态落到当前 session，并最终导航回业务目标。
 
-用户明确说 RND 环境：
+### 用户给了具体 Forge/DC URL
+
+不要要求先 open。直接创建 session，把 URL 传给 provider：
 
 ```bash
-pw session create dc2 --headed --open 'https://developer.xdrnd.cn/forge'
+pw session create dc2 --headed
+pw auth dc --session dc2 --arg targetUrl='https://developer.xdrnd.cn/forge'
+```
+
+### 用户没给 URL
+
+不要猜本机 IP。直接创建 session，让 provider 使用默认本地 Forge：
+
+```bash
+pw session create dc2 --headed
 pw auth dc --session dc2
 ```
 
-用户没给 URL 且没说 RND：不要问，直接执行默认登录命令。
+### 已有 session 当前页是 Forge/DC
+
+直接 auth，provider 会使用当前 Forge 页面作为目标：
+
+```bash
+pw auth dc --session dc2
+```
+
+## 登录步骤
+
+1. 确定目标来源。
+
+优先级：
+
+1. `--arg targetUrl=<url>`
+2. 当前 session 的 Forge 页面 URL
+3. 默认本地 Forge URL
 
 默认登录失败且错误要求 `targetUrl`：让用户给 Forge 链接，再重试。
 
@@ -39,12 +66,6 @@ pw session create dc2 --headed
 
 ```bash
 pw session create dc2
-```
-
-如果用户给了 URL 或明确 RND：
-
-```bash
-pw session create dc2 --headed --open '<forge-url>'
 ```
 
 4. 执行内置 provider。
@@ -86,7 +107,6 @@ pw auth dc --session dc2 --arg phone=19545672859 --arg targetUrl='<forge-url>'
 打开了错误域名：
 
 ```bash
-pw open --session dc2 '<correct-forge-url>'
 pw auth dc --session dc2 --arg phone='<phone>' --arg targetUrl='<correct-forge-url>'
 ```
 

--- a/skills/pwcli/references/gotchas.md
+++ b/skills/pwcli/references/gotchas.md
@@ -102,5 +102,29 @@ pw read-text --session <name> --max-chars 2000
 只有需要 aria ref 或结构定位时才用：
 
 ```bash
-pw snapshot --session <name>
+pw snapshot -i --session <name>
 ```
+
+大页面顺序：
+
+```bash
+pw read-text --session <name> --selector '<main-or-panel>' --max-chars 2000
+pw locate --session <name> --selector '<candidate-selector>'
+pw snapshot -i --session <name>
+pw snapshot -c --session <name>
+```
+
+全量 `pw snapshot --session <name>` 放最后。当前命令面如果有 depth 限制，先用 depth，不默认倾倒完整页面树。
+
+## read-text 成功优先 {#read-text-before-diagnostics}
+
+如果目标内容已经被 `read-text` 读到，diagnostics 里的第三方 warning、favicon 404、浏览器扩展噪声、无关 requestfailed 只作为背景记录。只有页面内容缺失、动作失败、白屏、目标接口异常或 page error 影响主路径时，才把 diagnostics 当主证据。
+
+## 不自动解 challenge {#challenge-fallback}
+
+遇到搜索引擎 challenge、CAPTCHA、Cloudflare challenge：
+
+- 不写自动解挑战脚本。
+- 先换 direct URL、站内搜索、官方 docs、site-specific 文档页。
+- 需要人类确认时打开 headed session 或 dashboard 让人接管。
+- 人接管后用 `read-text` / `locate` 继续验证，不把 challenge 解决过程纳入自动化主链。

--- a/skills/pwcli/workflows/browser-task.md
+++ b/skills/pwcli/workflows/browser-task.md
@@ -35,6 +35,17 @@ pw page current -s <name>
 pw read-text -s <name> --max-chars 2000
 ```
 
+如果页面很大，先 scoped，再 compact，不要直接全量 snapshot：
+
+```bash
+pw read-text -s <name> --selector '<main-or-panel>' --max-chars 2000
+pw locate -s <name> --text '<visible text>'
+pw snapshot -i -s <name>
+pw snapshot -c -s <name>
+```
+
+只有 scoped / interactive / compact 不足以回答问题时，才使用全量 `pw snapshot -s <name>`。如果当前命令面暴露 depth 参数，先用 depth 限制层级。
+
 多页面、popup、新开预览页：
 
 ```bash
@@ -48,7 +59,7 @@ pw tab close <pageId> -s <name>
 需要 aria ref：
 
 ```bash
-pw snapshot -s <name>
+pw snapshot -i -s <name>
 ```
 
 ## 动作
@@ -77,4 +88,4 @@ pw read-text -s <name> --max-chars 2000
 pw diagnostics digest -s <name>
 ```
 
-如果出现错误、白屏、接口失败，按 `SKILL.md` 的 Bug 诊断流程继续。
+如果 `read-text` 已经确认页面内容可读，console/network 里的第三方 warning、favicon 404、扩展噪声只作为背景。只有内容缺失、动作失败、白屏、接口 4xx/5xx 或 page error 影响目标路径时，才进入 diagnostics 主流程。

--- a/skills/pwcli/workflows/diagnostics.md
+++ b/skills/pwcli/workflows/diagnostics.md
@@ -8,6 +8,14 @@
 
 ## 1. 快速总览
 
+先确认内容事实：
+
+```bash
+pw read-text --session <name> --max-chars 2000
+```
+
+如果目标内容已读到，diagnostics 里的背景噪声不要升级成失败；只记录和目标路径有关的 console/network/page error。
+
 ```bash
 pw diagnostics digest --session <name>
 ```
@@ -117,6 +125,15 @@ pw dialog dismiss --session <name>
 ```bash
 pw session recreate <name> --open '<url>'
 ```
+
+## 9. Search / challenge fallback
+
+遇到搜索引擎 challenge、CAPTCHA、人机验证、Cloudflare challenge：
+
+- 不自动解挑战，不写滑块/验证码绕过脚本。
+- 优先改用 direct URL、站内 docs、site-specific 文档页或已有深链。
+- 如果必须确认挑战后内容，交给 human takeover：`pw dashboard open` 或让用户在 headed session 中接管。
+- 接管后再用 `pw read-text` / `pw locate` 验证内容，不把 challenge 解决过程写成自动化 workflow。
 
 ## 输出要求
 

--- a/src/app/commands/auth.ts
+++ b/src/app/commands/auth.ts
@@ -159,6 +159,12 @@ export function registerAuthCommand(program: Command): void {
             : providerResult?.page && typeof providerResult.page === "object"
               ? (providerResult.page as Record<string, unknown>)
               : undefined;
+        const resolvedTargetUrl =
+          typeof providerResult?.resolvedTargetUrl === "string"
+            ? providerResult.resolvedTargetUrl
+            : undefined;
+        const resolvedBy =
+          typeof providerResult?.resolvedBy === "string" ? providerResult.resolvedBy : undefined;
 
         if (options.saveState) {
           await managedStateSave(options.saveState, { sessionName });
@@ -169,7 +175,8 @@ export function registerAuthCommand(program: Command): void {
           page: result.page,
           data: {
             provider: provider.name,
-            args,
+            ...(resolvedTargetUrl ? { resolvedTargetUrl } : {}),
+            ...(resolvedBy ? { resolvedBy } : {}),
             pageState,
             ...(options.saveState ? { stateSaved: options.saveState } : {}),
             result: result.data.result,

--- a/src/app/commands/check.ts
+++ b/src/app/commands/check.ts
@@ -7,33 +7,49 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 export function registerCheckCommand(program: Command): void {
   addSessionOption(
     program
       .command("check [ref]")
       .description("Check a checkbox or radio target by ref or selector")
-      .option("--selector <selector>", "Selector target"),
-  ).action(async (ref: string | undefined, options: { selector?: string; session?: string }) => {
-    try {
-      const sessionName = requireSessionName(options);
-      printCommandResult(
-        "check",
-        await managedCheck({
-          ref,
-          selector: options.selector,
-          sessionName,
-        }),
-      );
-    } catch (error) {
-      printSessionAwareCommandError("check", error, {
-        code: "CHECK_FAILED",
-        message: "check failed",
-        suggestions: [
-          "Use `pw check --session bug-a e6` or `pw check --session bug-a --selector '#agree'`",
-          "Run `pw snapshot -i --session bug-a` to refresh refs",
-        ],
-      });
-      process.exitCode = 1;
-    }
-  });
+      .option("--selector <selector>", "Selector target")
+      .option("--nth <number>", "1-based match index", "1"),
+  ).action(
+    async (
+      ref: string | undefined,
+      options: { selector?: string; nth?: string; session?: string },
+    ) => {
+      try {
+        const sessionName = requireSessionName(options);
+        const nth = parseNth(options.nth);
+        printCommandResult(
+          "check",
+          await managedCheck({
+            ref,
+            selector: options.selector,
+            nth: options.selector ? nth : undefined,
+            sessionName,
+          }),
+        );
+      } catch (error) {
+        printSessionAwareCommandError("check", error, {
+          code: "CHECK_FAILED",
+          message: "check failed",
+          suggestions: [
+            "Use `pw check --session bug-a e6` or `pw check --session bug-a --selector '#agree'`",
+            "Run `pw snapshot -i --session bug-a` to refresh refs",
+          ],
+        });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/src/app/commands/click.ts
+++ b/src/app/commands/click.ts
@@ -31,19 +31,20 @@ export function registerClickCommand(program: Command): void {
   ).action(async (ref: string | undefined, options: Record<string, string>) => {
     try {
       const sessionName = requireSessionName(options);
+      const nth = parseNth(options.nth);
       if (ref || options.selector) {
         printCommandResult(
           "click",
           await managedClick({
             ref,
             selector: options.selector,
+            nth: options.selector ? nth : undefined,
             sessionName,
           }),
         );
         return;
       }
 
-      const nth = parseNth(options.nth);
       if (options.role) {
         printCommandResult(
           "click",

--- a/src/app/commands/download.ts
+++ b/src/app/commands/download.ts
@@ -14,16 +14,30 @@ export function registerDownloadCommand(program: Command): void {
       .description("Trigger a download from an aria ref or selector")
       .option("--selector <selector>", "Selector target")
       .option("--path <path>", "Output file path")
-      .option("--dir <dir>", "Output directory; saved filename uses the browser suggested name"),
+      .option("--dir <dir>", "Output directory; saved filename uses the browser suggested name")
+      .option(
+        "--download-dir <dir>",
+        "Alias for --dir; saved filename uses the browser suggested name",
+      ),
   ).action(
     async (
       ref: string | undefined,
-      options: { session?: string; selector?: string; path?: string; dir?: string },
+      options: {
+        session?: string;
+        selector?: string;
+        path?: string;
+        dir?: string;
+        downloadDir?: string;
+      },
     ) => {
       try {
         const sessionName = requireSessionName(options);
-        if (options.path && options.dir) {
-          throw new Error("download accepts either --path or --dir, not both");
+        if (options.dir && options.downloadDir) {
+          throw new Error("download accepts either --dir or --download-dir, not both");
+        }
+        const dir = options.dir ?? options.downloadDir;
+        if (options.path && dir) {
+          throw new Error("download accepts either --path or --dir/--download-dir, not both");
         }
         printCommandResult(
           "download",
@@ -31,7 +45,7 @@ export function registerDownloadCommand(program: Command): void {
             ref,
             selector: options.selector,
             path: options.path,
-            dir: options.dir,
+            dir,
             sessionName,
           }),
         );
@@ -42,6 +56,7 @@ export function registerDownloadCommand(program: Command): void {
           suggestions: [
             "Use `pw download --session bug-a e6 --path ./.tmp-downloads/file.bin` for an exact file path",
             "Use `pw download --session bug-a e6 --dir ./.tmp-downloads` to keep the suggested filename",
+            "Use `pw download --session bug-a e6 --download-dir ./.tmp-downloads` as an alias for --dir",
           ],
         });
         process.exitCode = 1;

--- a/src/app/commands/fill.ts
+++ b/src/app/commands/fill.ts
@@ -69,6 +69,7 @@ export function registerFillCommand(program: Command): void {
     try {
       const sessionName = requireSessionName(options);
       const values = Array.isArray(parts) ? parts : [];
+      const nth = parseNth(options.nth);
       const semantic = buildSemanticTarget(options);
       const ref = options.selector || semantic ? undefined : values[0];
       const value = options.selector || semantic ? values.join(" ") : values.slice(1).join(" ");
@@ -80,6 +81,7 @@ export function registerFillCommand(program: Command): void {
         await managedFill({
           ref,
           selector: options.selector,
+          nth: options.selector ? nth : undefined,
           semantic,
           value,
           sessionName,

--- a/src/app/commands/hover.ts
+++ b/src/app/commands/hover.ts
@@ -7,34 +7,50 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 export function registerHoverCommand(program: Command): void {
   addSessionOption(
     program
       .command("hover [ref]")
       .description("Hover an element by aria ref or selector")
-      .option("--selector <selector>", "Selector target"),
-  ).action(async (ref: string | undefined, options: { selector?: string; session?: string }) => {
-    try {
-      const sessionName = requireSessionName(options);
-      printCommandResult(
-        "hover",
-        await managedHover({
-          ref,
-          selector: options.selector,
-          sessionName,
-        }),
-      );
-    } catch (error) {
-      printSessionAwareCommandError("hover", error, {
-        code: "HOVER_FAILED",
-        message: "hover failed",
-        suggestions: [
-          "Use `pw hover --session bug-a e6` or `pw hover --session bug-a --selector '.menu-trigger'`",
-          "If the page changed, refresh refs with `pw snapshot -i --session <name>`",
-          "After hovering, inspect revealed menus with `pw read-text --session <name> --include-overlay`",
-        ],
-      });
-      process.exitCode = 1;
-    }
-  });
+      .option("--selector <selector>", "Selector target")
+      .option("--nth <number>", "1-based match index", "1"),
+  ).action(
+    async (
+      ref: string | undefined,
+      options: { selector?: string; nth?: string; session?: string },
+    ) => {
+      try {
+        const sessionName = requireSessionName(options);
+        const nth = parseNth(options.nth);
+        printCommandResult(
+          "hover",
+          await managedHover({
+            ref,
+            selector: options.selector,
+            nth: options.selector ? nth : undefined,
+            sessionName,
+          }),
+        );
+      } catch (error) {
+        printSessionAwareCommandError("hover", error, {
+          code: "HOVER_FAILED",
+          message: "hover failed",
+          suggestions: [
+            "Use `pw hover --session bug-a e6` or `pw hover --session bug-a --selector '.menu-trigger'`",
+            "If the page changed, refresh refs with `pw snapshot -i --session <name>`",
+            "After hovering, inspect revealed menus with `pw read-text --session <name> --include-overlay`",
+          ],
+        });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/src/app/commands/select.ts
+++ b/src/app/commands/select.ts
@@ -7,20 +7,30 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 export function registerSelectCommand(program: Command): void {
   addSessionOption(
     program
       .command("select <targetOrValue> [value]")
       .description("Select an option value by ref or selector")
-      .option("--selector <selector>", "Selector target"),
+      .option("--selector <selector>", "Selector target")
+      .option("--nth <number>", "1-based match index", "1"),
   ).action(
     async (
       targetOrValue: string,
       value: string | undefined,
-      options: { selector?: string; session?: string },
+      options: { selector?: string; nth?: string; session?: string },
     ) => {
       try {
         const sessionName = requireSessionName(options);
+        const nth = parseNth(options.nth);
         const ref = options.selector ? undefined : targetOrValue;
         const selectedValue = options.selector ? targetOrValue : value;
         if (!selectedValue) {
@@ -32,6 +42,7 @@ export function registerSelectCommand(program: Command): void {
             ref,
             selector: options.selector,
             sessionName,
+            nth: options.selector ? nth : undefined,
             value: selectedValue,
           }),
         );

--- a/src/app/commands/type.ts
+++ b/src/app/commands/type.ts
@@ -69,6 +69,7 @@ export function registerTypeCommand(program: Command): void {
     try {
       const sessionName = requireSessionName(options);
       const values = Array.isArray(parts) ? parts : [];
+      const nth = parseNth(options.nth);
       const semantic = buildSemanticTarget(options);
       const ref =
         options.selector || semantic ? undefined : values.length > 1 ? values[0] : undefined;
@@ -86,6 +87,7 @@ export function registerTypeCommand(program: Command): void {
         await managedType({
           ref,
           selector: options.selector,
+          nth: options.selector ? nth : undefined,
           semantic,
           value,
           sessionName,

--- a/src/app/commands/uncheck.ts
+++ b/src/app/commands/uncheck.ts
@@ -7,33 +7,49 @@ import {
   requireSessionName,
 } from "./session-options.js";
 
+function parseNth(value?: string) {
+  const nth = Number(value ?? "1");
+  if (!Number.isInteger(nth) || nth < 1) {
+    throw new Error("--nth requires a positive integer");
+  }
+  return nth;
+}
+
 export function registerUncheckCommand(program: Command): void {
   addSessionOption(
     program
       .command("uncheck [ref]")
       .description("Uncheck a checkbox target by ref or selector")
-      .option("--selector <selector>", "Selector target"),
-  ).action(async (ref: string | undefined, options: { selector?: string; session?: string }) => {
-    try {
-      const sessionName = requireSessionName(options);
-      printCommandResult(
-        "uncheck",
-        await managedUncheck({
-          ref,
-          selector: options.selector,
-          sessionName,
-        }),
-      );
-    } catch (error) {
-      printSessionAwareCommandError("uncheck", error, {
-        code: "UNCHECK_FAILED",
-        message: "uncheck failed",
-        suggestions: [
-          "Use `pw uncheck --session bug-a e6` or `pw uncheck --session bug-a --selector '#agree'`",
-          "Run `pw snapshot -i --session bug-a` to refresh refs",
-        ],
-      });
-      process.exitCode = 1;
-    }
-  });
+      .option("--selector <selector>", "Selector target")
+      .option("--nth <number>", "1-based match index", "1"),
+  ).action(
+    async (
+      ref: string | undefined,
+      options: { selector?: string; nth?: string; session?: string },
+    ) => {
+      try {
+        const sessionName = requireSessionName(options);
+        const nth = parseNth(options.nth);
+        printCommandResult(
+          "uncheck",
+          await managedUncheck({
+            ref,
+            selector: options.selector,
+            nth: options.selector ? nth : undefined,
+            sessionName,
+          }),
+        );
+      } catch (error) {
+        printSessionAwareCommandError("uncheck", error, {
+          code: "UNCHECK_FAILED",
+          message: "uncheck failed",
+          suggestions: [
+            "Use `pw uncheck --session bug-a e6` or `pw uncheck --session bug-a --selector '#agree'`",
+            "Run `pw snapshot -i --session bug-a` to refresh refs",
+          ],
+        });
+        process.exitCode = 1;
+      }
+    },
+  );
 }

--- a/src/app/output.ts
+++ b/src/app/output.ts
@@ -152,6 +152,9 @@ function formatRunPointer(value: unknown): string | null {
 
 function formatDiagnosticsDelta(value: unknown): string[] {
   const delta = asRecord(value);
+  if (delta.unavailable) {
+    return [`delta unavailable: ${asString(delta.reason) ?? "unknown"}`];
+  }
   const consoleDelta = asNumber(delta.consoleDelta) ?? 0;
   const networkDelta = asNumber(delta.networkDelta) ?? 0;
   const pageErrorDelta = asNumber(delta.pageErrorDelta) ?? 0;
@@ -281,6 +284,28 @@ function formatTraceInspect(result: CommandResult): string {
   return lines.join("\n");
 }
 
+function formatTrace(result: CommandResult): string {
+  const action = asString(result.data.action) ?? "trace";
+  const facts = [
+    result.data.started === true ? "started=true" : null,
+    result.data.stopped === true ? "stopped=true" : null,
+  ].filter(Boolean);
+  const lines = [`trace ${action}${facts.length > 0 ? ` ${facts.join(" ")}` : ""}`];
+  const artifactPath = asString(result.data.traceArtifactPath);
+  if (artifactPath) {
+    lines.push(`artifact=${artifactPath}`);
+  }
+  const nextStep = asString(result.data.nextStep);
+  if (nextStep) {
+    lines.push(`next=${nextStep}`);
+  }
+  const inspectHint = asString(result.data.inspectHint);
+  if (inspectHint) {
+    lines.push(`hint=${inspectHint}`);
+  }
+  return lines.join("\n");
+}
+
 function formatPage(result: CommandResult): string {
   const current = asRecord(result.data.currentPage);
   const pages = asArray(result.data.pages);
@@ -331,6 +356,7 @@ function formatAction(command: string, result: CommandResult): string {
     "checked",
     "selected",
     "saved",
+    "modalPending",
   ];
   const facts = keys
     .filter((key) => key in result.data)
@@ -339,9 +365,18 @@ function formatAction(command: string, result: CommandResult): string {
   if (page) {
     lines.push(`page ${page}`);
   }
+  const blockedState = asString(result.data.blockedState);
+  if (blockedState) {
+    lines.push(`blockedState=${blockedState}`);
+  }
   const runPointer = formatRunPointer(result.data.run);
   if (runPointer) {
     lines.push(runPointer);
+  }
+  const nextSteps = asArray(result.data.nextSteps).map(String);
+  if (nextSteps.length > 0) {
+    lines.push("Next steps:");
+    lines.push(...nextSteps.map((item) => `- ${item}`));
   }
   lines.push(...formatDiagnosticsDelta(result.data.diagnosticsDelta));
   return lines.join("\n");
@@ -385,8 +420,14 @@ function formatStateCheck(command: string, result: CommandResult): string {
       const tagName = asString(item.tagName) ?? "node";
       const visible = Boolean(item.visible);
       const text = asString(item.text) ?? "";
+      const href = asString(item.href);
+      const role = asString(item.role);
+      const name = asString(item.name);
+      const region = asString(item.region);
+      const ancestor = asString(item.ancestor);
+      const selectorHint = asString(item.selectorHint);
       lines.push(
-        `${index}. ${tagName} visible=${visible}${text ? ` text=${JSON.stringify(text)}` : ""}`,
+        `${index}. ${tagName} visible=${visible}${role ? ` role=${JSON.stringify(role)}` : ""}${name ? ` name=${JSON.stringify(name)}` : ""}${href ? ` href=${JSON.stringify(href)}` : ""}${region ? ` region=${JSON.stringify(region)}` : ""}${ancestor ? ` ancestor=${JSON.stringify(ancestor)}` : ""}${selectorHint ? ` selectorHint=${JSON.stringify(selectorHint)}` : ""}${text ? ` text=${JSON.stringify(text)}` : ""}`,
       );
     }
     return lines.join("\n");
@@ -485,6 +526,9 @@ function formatCommandText(command: string, result: CommandResult): string {
   }
   if (command === "trace inspect") {
     return formatTraceInspect(result);
+  }
+  if (command === "trace start" || command === "trace stop") {
+    return formatTrace(result);
   }
   if (command.startsWith("page ")) {
     return formatPage(result);

--- a/src/domain/diagnostics/service.ts
+++ b/src/domain/diagnostics/service.ts
@@ -242,6 +242,17 @@ function toNetworkSignal(record: Record<string, unknown>): SignalRecord {
   };
 }
 
+function toFailureSignal(record: Record<string, unknown>): SignalRecord {
+  const code = asString(record.code) ?? "COMMAND_FAILED";
+  const message = asString(record.message) ?? "";
+  return {
+    kind: `failure:${code}`,
+    timestamp: asString(record.timestamp),
+    summary: message || code,
+    details: record,
+  };
+}
+
 function buildSessionDigestFromExport(
   exported: Awaited<ReturnType<typeof managedDiagnosticsExport>>,
   limit: number,
@@ -318,8 +329,26 @@ function collectRunSignals(event: RunEventRecord): SignalRecord[] {
   const pageError = asObject(diagnosticsDelta.lastPageError);
   const consoleRecord = asObject(diagnosticsDelta.lastConsole);
   const networkRecord = asObject(diagnosticsDelta.lastNetwork);
+  const failure = asObject(event.failure);
+  const failureSignal = asObject(event.failureSignal);
   const signals: SignalRecord[] = [];
 
+  if (Object.keys(failure).length > 0) {
+    signals.push(
+      toFailureSignal({
+        ...failure,
+        timestamp: eventTimestamp(event),
+      }),
+    );
+  }
+  if (Object.keys(failureSignal).length > 0) {
+    signals.push(
+      toFailureSignal({
+        ...failureSignal,
+        timestamp: eventTimestamp(event),
+      }),
+    );
+  }
   if (Object.keys(pageError).length > 0) {
     signals.push(toPageErrorSignal(pageError));
   }
@@ -354,6 +383,14 @@ function buildRunDigest(runId: string, events: RunEventRecord[], limit: number) 
     const value = asNumber(asObject(event.diagnosticsDelta).pageErrorDelta);
     return sum + (value ?? 0);
   }, 0);
+  const failureCount = events.filter(
+    (event) => Boolean(event.failed) || Object.keys(asObject(event.failure)).length > 0,
+  ).length;
+  const dialogPendingCount = events.filter(
+    (event) =>
+      event.modalPending === true ||
+      asString(asObject(event.failureSignal).code) === "MODAL_STATE_BLOCKED",
+  ).length;
 
   const topSignals = limitSignals(
     events.flatMap((event) => collectRunSignals(event)),
@@ -366,10 +403,15 @@ function buildRunDigest(runId: string, events: RunEventRecord[], limit: number) 
       command: asString(event.command),
       pageId: asString(event.pageId),
       navigationId: asString(event.navigationId),
+      status: asString(event.status) ?? (event.failed ? "failed" : "ok"),
+      failed: Boolean(event.failed),
+      modalPending: event.modalPending === true,
       summary: {
         consoleDelta: asNumber(diagnosticsDelta.consoleDelta) ?? 0,
         networkDelta: asNumber(diagnosticsDelta.networkDelta) ?? 0,
         pageErrorDelta: asNumber(diagnosticsDelta.pageErrorDelta) ?? 0,
+        failureCode: asString(asObject(event.failure).code),
+        failureSignalCode: asString(asObject(event.failureSignal).code),
       },
     };
   });
@@ -385,6 +427,8 @@ function buildRunDigest(runId: string, events: RunEventRecord[], limit: number) 
       consoleDeltaTotal,
       networkDeltaTotal,
       pageErrorDeltaTotal,
+      failureCount,
+      dialogPendingCount,
       signalCount: topSignals.length,
     },
     topSignals,
@@ -411,15 +455,36 @@ export function buildDiagnosticsAuditConclusion(input: {
   const lastEvent = asObject(events.at(-1) ?? {});
   const lastCommand = asString(lastEvent.command);
   const lastTs = asString(lastEvent.ts) ?? asString(lastEvent.timestamp);
+  const lastFailure = asObject(lastEvent.failure);
+  const lastFailureSignal = asObject(lastEvent.failureSignal);
   const pageErrorCount = asNumber(summary.pageErrorCount) ?? 0;
   const failedRequestCount = asNumber(summary.failedRequestCount) ?? 0;
   const consoleErrorCount = asNumber(summary.consoleErrorCount) ?? 0;
   const httpErrorCount = asNumber(summary.httpErrorCount) ?? 0;
+  const latestRunHasFailure = events.some(
+    (event) => Boolean(event.failed) || Object.keys(asObject(event.failure)).length > 0,
+  );
+  const latestRunHasFailureSignal = events.some(
+    (event) => Object.keys(asObject(event.failureSignal)).length > 0,
+  );
   const failureLikely =
-    pageErrorCount > 0 || failedRequestCount > 0 || consoleErrorCount > 0 || httpErrorCount > 0;
+    pageErrorCount > 0 ||
+    failedRequestCount > 0 ||
+    consoleErrorCount > 0 ||
+    httpErrorCount > 0 ||
+    latestRunHasFailure ||
+    latestRunHasFailureSignal;
   const firstSignal = asObject(topSignals[0] ?? {});
-  const failureKind = asString(firstSignal.kind) ?? null;
-  const failureSummary = asString(firstSignal.summary) ?? null;
+  const failureKind =
+    asString(lastFailure.code) ??
+    asString(lastFailureSignal.code) ??
+    asString(firstSignal.kind) ??
+    null;
+  const failureSummary =
+    asString(lastFailure.message) ??
+    asString(lastFailureSignal.message) ??
+    asString(firstSignal.summary) ??
+    null;
   const latestRunId = input.latestRunId ?? asString(latestRunEvents.runId);
   const limit = Math.max(1, input.limit);
   const grepText = failureSummary ?? failureKind ?? "error";

--- a/src/domain/session/routing.ts
+++ b/src/domain/session/routing.ts
@@ -39,6 +39,21 @@ export function sessionRoutingError(message: string) {
     };
   }
 
+  if (message.startsWith("SESSION_BUSY:")) {
+    const [, name, timeoutMs] = message.split(":");
+    return {
+      code: "SESSION_BUSY",
+      message: `Session '${name}' is still running another command.`,
+      retryable: true,
+      suggestions: [
+        "Retry the same command after the in-flight command finishes",
+        "Keep dependent commands on the same session sequential, or put stable steps in `pw batch`",
+        "If the owner process is gone, retry after the lock is reclaimed automatically",
+      ],
+      details: { session: name, timeoutMs: Number(timeoutMs) },
+    };
+  }
+
   if (message.startsWith("SESSION_NAME_TOO_LONG:")) {
     const [, name, limit] = message.split(":");
     return {

--- a/src/infra/auth-providers/dc.ts
+++ b/src/infra/auth-providers/dc.ts
@@ -10,15 +10,70 @@ const dcProviderSource = String(async (page, args) => {
     const match = String(raw || "").match(/^(https?:\/\/[^/]+)(?:\/.*)?$/);
     return match?.[1] || "";
   };
+  const pathFromUrl = (raw) => {
+    const origin = originFromUrl(raw);
+    return origin ? String(raw || "").slice(origin.length) || "/" : "";
+  };
+  const queryParam = (raw, name) => {
+    const decode = (value) => {
+      try {
+        return decodeURIComponent(value || "");
+      } catch {
+        return value || "";
+      }
+    };
+    const query =
+      String(raw || "")
+        .split("?")[1]
+        ?.split("#")[0] || "";
+    for (const part of query.split("&")) {
+      const [key, ...valueParts] = part.split("=");
+      if (decode(key) === name) {
+        return decode(valueParts.join("="));
+      }
+    }
+    return "";
+  };
+  const forgeTargetFromUrl = (raw) => {
+    const url = String(raw || "").trim();
+    const origin = originFromUrl(url);
+    if (!origin) {
+      return "";
+    }
+    const host = origin.replace(/^https?:\/\//, "");
+    if (!host.startsWith("developer")) {
+      return "";
+    }
+    const path = pathFromUrl(url);
+    if (path.startsWith("/forge/auth/login")) {
+      const refer = queryParam(url, "refer");
+      return forgeTargetFromUrl(refer);
+    }
+    if (path === "/" || path === "") {
+      return `${origin}/forge`;
+    }
+    return path.startsWith("/forge") ? url : "";
+  };
   const phone = String(args.phone ?? "19545672859").trim();
   const smsCode = String(args.smsCode ?? "000000").trim();
   const explicitTargetUrl = String(args.targetUrl ?? "").trim();
-  const resolvedBy = String(args.resolvedBy ?? "").trim();
+  let resolvedBy = "";
   let baseURL = String(args.baseURL ?? "")
     .trim()
     .replace(/\/$/, "");
 
-  let targetUrl = explicitTargetUrl || String(args.detectedTargetUrl ?? "").trim();
+  let targetUrl = "";
+  if (explicitTargetUrl) {
+    targetUrl = explicitTargetUrl;
+    resolvedBy = "targetUrl";
+  } else if (baseURL) {
+    targetUrl = `${baseURL}/forge`;
+    resolvedBy = "baseURL";
+  } else {
+    const currentTargetUrl = forgeTargetFromUrl(page.url());
+    targetUrl = currentTargetUrl || String(args.detectedTargetUrl ?? "").trim();
+    resolvedBy = currentTargetUrl ? "current-page" : String(args.resolvedBy ?? "").trim();
+  }
 
   if (!baseURL && targetUrl) {
     baseURL = originFromUrl(targetUrl);
@@ -32,7 +87,7 @@ const dcProviderSource = String(async (page, args) => {
   }
   if (!baseURL || !targetUrl) {
     throw new Error(
-      "DC_AUTH_URL_REQUIRED: dc auth could not resolve Forge URL. Open the session on Forge first or pass --arg targetUrl=<url>.",
+      "DC_AUTH_URL_REQUIRED: dc auth could not resolve Forge URL. Pass --arg targetUrl=<url> or run from an existing Forge page.",
     );
   }
 
@@ -178,6 +233,9 @@ const dcProviderSource = String(async (page, args) => {
 
   return {
     ok: true,
+    resolvedTargetUrl: targetUrl,
+    resolvedBy,
+    baseURL,
     pageState: await page.evaluate(() => ({
       url: window.location.href,
       title: document.title,
@@ -191,7 +249,7 @@ export const dcAuthProvider: AuthProviderSpec = {
   name: "dc",
   summary: "TapTap/Forge DC 登录 provider",
   description:
-    "在现有 session 内执行 DC 登录链。默认使用测试手机号和万能验证码；传了 targetUrl 就使用指定业务 URL。",
+    "在现有 session 内执行 DC 登录链。传了 targetUrl 就使用指定业务 URL；否则优先使用当前 Forge 页面，最后回退默认本地 Forge。",
   source: dcProviderSource,
   args: [
     {
@@ -220,7 +278,8 @@ export const dcAuthProvider: AuthProviderSpec = {
   ],
   notes: [
     "传了 `targetUrl` 就用 `targetUrl`。",
-    "未传 URL 时直接执行默认登录流程。",
+    "未传 URL 时，先尝试使用当前 session 的 Forge 页面 URL。",
+    "当前页不是 Forge 时，回退到默认本地 Forge URL。",
     "默认登录失败时，传 `--arg targetUrl=<forge-url>`。",
   ],
   resolveArgs: resolveDcArgs,

--- a/src/infra/playwright/cli-client.ts
+++ b/src/infra/playwright/cli-client.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 
@@ -14,6 +16,8 @@ const { serverRegistry } = serverRegistryModule;
 
 export const DEFAULT_SESSION_NAME = "default";
 export const MAX_SESSION_NAME_LENGTH = 16;
+const SESSION_LOCK_TIMEOUT_MS = Number(process.env.PWCLI_SESSION_LOCK_TIMEOUT_MS ?? 120_000);
+const SESSION_LOCK_STALE_MS = Number(process.env.PWCLI_SESSION_LOCK_STALE_MS ?? 600_000);
 
 type ManagedSessionConfig = {
   name?: string;
@@ -138,6 +142,105 @@ async function getSessionEntry(sessionName?: string) {
     sessionName: resolvedSessionName,
     entry,
   };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid: unknown) {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readLockOwner(lockDir: string) {
+  try {
+    return JSON.parse(await readFile(join(lockDir, "owner.json"), "utf8")) as {
+      pid?: number;
+      token?: string;
+      acquiredAt?: string;
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function isStaleSessionLock(lockDir: string) {
+  const owner = await readLockOwner(lockDir);
+  if (owner?.pid && isProcessAlive(owner.pid)) {
+    return false;
+  }
+  if (owner?.pid && !isProcessAlive(owner.pid)) {
+    return true;
+  }
+  try {
+    const info = await stat(lockDir);
+    return Date.now() - info.mtimeMs > SESSION_LOCK_STALE_MS;
+  } catch {
+    return true;
+  }
+}
+
+async function withSessionCommandLock<T>(
+  workspaceDir: string | undefined,
+  sessionName: string,
+  fn: () => Promise<T>,
+) {
+  const root = resolve(workspaceDir ?? process.cwd(), ".pwcli", "locks");
+  const lockDir = join(root, `${sessionName}.lock`);
+  const token = randomUUID();
+  const startedAt = Date.now();
+
+  await mkdir(root, { recursive: true });
+
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      await writeFile(
+        join(lockDir, "owner.json"),
+        JSON.stringify(
+          {
+            pid: process.pid,
+            token,
+            sessionName,
+            acquiredAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+      );
+      break;
+    } catch (error) {
+      const code = error && typeof error === "object" ? (error as { code?: string }).code : "";
+      if (code !== "EEXIST") {
+        throw error;
+      }
+      if (await isStaleSessionLock(lockDir)) {
+        await rm(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - startedAt > SESSION_LOCK_TIMEOUT_MS) {
+        throw new Error(`SESSION_BUSY:${sessionName}:${SESSION_LOCK_TIMEOUT_MS}`);
+      }
+      await sleep(50 + Math.floor(Math.random() * 100));
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    const owner = await readLockOwner(lockDir);
+    if (owner?.token === token) {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  }
 }
 
 export async function getManagedSessionEntry(sessionName?: string) {
@@ -294,16 +397,18 @@ export async function runManagedSessionCommand(
   },
 ) {
   const { clientInfo, sessionName, session } = await ensureManagedSession(options);
-  const run = session.run(clientInfo, {
-    ...args,
+  const text = await withSessionCommandLock(clientInfo.workspaceDir, sessionName, async () => {
+    const run = session.run(clientInfo, {
+      ...args,
+    });
+    return options?.timeoutMs
+      ? await withManagedSessionTimeout(run, {
+          timeoutMs: options.timeoutMs,
+          timeoutMessage: options.timeoutMessage,
+          timeoutCode: options.timeoutCode,
+        })
+      : await run;
   });
-  const text = options?.timeoutMs
-    ? await withManagedSessionTimeout(run, {
-        timeoutMs: options.timeoutMs,
-        timeoutMessage: options.timeoutMessage,
-        timeoutCode: options.timeoutCode,
-      })
-    : await run;
   return {
     sessionName,
     text: text.text,

--- a/src/infra/playwright/runtime/action-failure-classifier.ts
+++ b/src/infra/playwright/runtime/action-failure-classifier.ts
@@ -10,7 +10,8 @@ function isTargetNotFoundError(errorText: string) {
   if (
     /No element matches selector/i.test(errorText) ||
     /Unable to find/i.test(errorText) ||
-    /(CLICK|FILL|TYPE)_SEMANTIC_NOT_FOUND/i.test(errorText)
+    /(CLICK|FILL|TYPE)_SEMANTIC_NOT_FOUND/i.test(errorText) ||
+    /(CLICK|FILL|TYPE|HOVER|CHECK|UNCHECK|SELECT)_SELECTOR_NOT_FOUND/i.test(errorText)
   ) {
     return true;
   }

--- a/src/infra/playwright/runtime/diagnostics.ts
+++ b/src/infra/playwright/runtime/diagnostics.ts
@@ -223,6 +223,7 @@ export async function managedTrace(action: "start" | "stop", options?: { session
   })
     .then((traceResult) => traceResult.data.result)
     .catch(() => undefined);
+  const traceArtifactPath = parseTraceArtifactPath(result.text);
 
   return {
     session: {
@@ -235,10 +236,23 @@ export async function managedTrace(action: "start" | "stop", options?: { session
       action,
       started: action === "start" ? true : undefined,
       stopped: action === "stop" ? true : undefined,
+      ...(traceArtifactPath ? { traceArtifactPath } : {}),
+      ...(action === "stop" && traceArtifactPath
+        ? {
+            nextStep: `pw trace inspect ${JSON.stringify(traceArtifactPath)} --section actions`,
+            inspectHint:
+              "Use `pw trace inspect <traceArtifactPath> --section actions|requests|console|errors` to inspect the saved trace artifact.",
+          }
+        : {}),
       ...(traceState ? { trace: traceState } : {}),
       ...maybeRawOutput(result.text),
     },
   };
+}
+
+function parseTraceArtifactPath(text: string) {
+  const match = text.match(/^- \[Trace\]\(([^)]+)\)$/m);
+  return match?.[1];
 }
 
 export async function managedErrors(

--- a/src/infra/playwright/runtime/interaction.ts
+++ b/src/infra/playwright/runtime/interaction.ts
@@ -10,7 +10,12 @@ import {
 } from "./action-failure-classifier.js";
 import { managedRunCode } from "./code.js";
 import { buildDiagnosticsDelta, captureDiagnosticsBaseline } from "./diagnostics.js";
-import { DIAGNOSTICS_STATE_KEY, maybeRawOutput, normalizeRef } from "./shared.js";
+import {
+  DIAGNOSTICS_STATE_KEY,
+  isModalStateBlockedMessage,
+  maybeRawOutput,
+  normalizeRef,
+} from "./shared.js";
 import { managedPageCurrent } from "./workspace.js";
 
 type SemanticTarget =
@@ -19,6 +24,11 @@ type SemanticTarget =
   | { kind: "label"; label: string; nth?: number }
   | { kind: "placeholder"; placeholder: string; nth?: number }
   | { kind: "testid"; testid: string; nth?: number };
+
+type SelectorTarget = {
+  selector: string;
+  nth?: number;
+};
 
 type RefEpochValidation =
   | {
@@ -59,6 +69,84 @@ async function recordRun(
   return run;
 }
 
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown, fallback: string) {
+  return error instanceof ActionFailure ? error.code : fallback;
+}
+
+function errorRetryable(error: unknown) {
+  return error instanceof ActionFailure ? error.retryable : undefined;
+}
+
+function errorSuggestions(error: unknown) {
+  return error instanceof ActionFailure ? error.suggestions : undefined;
+}
+
+function errorDetails(error: unknown) {
+  return error instanceof ActionFailure ? error.details : undefined;
+}
+
+async function buildDiagnosticsDeltaOrSignal(
+  sessionName: string | undefined,
+  before: { consoleTotal: number; networkTotal: number; pageErrorTotal: number },
+) {
+  try {
+    return await buildDiagnosticsDelta(sessionName, before);
+  } catch (error) {
+    return {
+      unavailable: true,
+      reason: errorMessage(error),
+    };
+  }
+}
+
+function attachFailureRun(error: unknown, run: Awaited<ReturnType<typeof recordRun>>) {
+  if (!(error instanceof ActionFailure)) {
+    return;
+  }
+  const details = {
+    ...(error.details ?? {}),
+    run,
+  };
+  Object.defineProperty(error, "details", {
+    value: details,
+    configurable: true,
+  });
+}
+
+function isModalBlockedDelta(delta: Record<string, unknown>) {
+  return delta.unavailable === true && isModalStateBlockedMessage(errorMessage(delta.reason));
+}
+
+async function recordFailedRun(
+  command: string,
+  sessionName: string | undefined,
+  page: Record<string, unknown> | undefined,
+  before: { consoleTotal: number; networkTotal: number; pageErrorTotal: number },
+  error: unknown,
+  details: Record<string, unknown> = {},
+) {
+  const diagnosticsDelta = await buildDiagnosticsDeltaOrSignal(sessionName, before);
+  const run = await recordRun(command, sessionName, page, {
+    ...details,
+    status: "failed",
+    failed: true,
+    diagnosticsDelta,
+    failure: {
+      code: errorCode(error, `${command.toUpperCase()}_FAILED`),
+      message: errorMessage(error),
+      retryable: errorRetryable(error) ?? null,
+      suggestions: errorSuggestions(error) ?? [],
+      details: errorDetails(error) ?? null,
+    },
+  });
+  attachFailureRun(error, run);
+  return run;
+}
+
 async function managedActionRunCode(options: {
   command: string;
   sessionName?: string;
@@ -75,6 +163,101 @@ async function managedActionRunCode(options: {
     }
     throw error;
   }
+}
+
+async function managedActionRunCodeWithFailureRun(options: {
+  command: string;
+  sessionName?: string;
+  source: string;
+  before: { consoleTotal: number; networkTotal: number; pageErrorTotal: number };
+  target?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+}) {
+  try {
+    return await managedActionRunCode({
+      command: options.command,
+      sessionName: options.sessionName,
+      source: options.source,
+    });
+  } catch (error) {
+    await recordFailedRun(options.command, options.sessionName, undefined, options.before, error, {
+      ...(options.target ? { target: options.target } : {}),
+      ...(options.details ?? {}),
+    });
+    throw error;
+  }
+}
+
+async function throwIfManagedActionErrorWithFailureRun(
+  text: string,
+  context: { command: string; sessionName?: string },
+  options: {
+    before: { consoleTotal: number; networkTotal: number; pageErrorTotal: number };
+    page?: Record<string, unknown>;
+    target?: Record<string, unknown>;
+    details?: Record<string, unknown>;
+  },
+) {
+  try {
+    throwIfManagedActionError(text, context);
+  } catch (error) {
+    await recordFailedRun(
+      context.command,
+      context.sessionName,
+      options.page,
+      options.before,
+      error,
+      {
+        ...(options.target ? { target: options.target } : {}),
+        ...(options.details ?? {}),
+      },
+    );
+    throw error;
+  }
+}
+
+function dialogPendingResult(options: {
+  command: string;
+  sessionName?: string;
+  resultText?: string;
+  page?: Record<string, unknown>;
+  target?: Record<string, unknown>;
+  before: { consoleTotal: number; networkTotal: number; pageErrorTotal: number };
+  diagnosticsDelta?: Record<string, unknown>;
+}) {
+  return (async () => {
+    const diagnosticsDelta =
+      options.diagnosticsDelta ??
+      (await buildDiagnosticsDeltaOrSignal(options.sessionName, options.before));
+    const run = await recordRun(options.command, options.sessionName, options.page, {
+      ...(options.target ? { target: options.target } : {}),
+      status: "dialog-pending",
+      acted: true,
+      modalPending: true,
+      diagnosticsDelta,
+      failureSignal: {
+        code: "MODAL_STATE_BLOCKED",
+        message: "action fired and a browser dialog is pending",
+      },
+    });
+    return {
+      session: {
+        scope: "managed",
+        name: options.sessionName ?? "default",
+        default: !options.sessionName || options.sessionName === "default",
+      },
+      page: options.page,
+      data: {
+        ...(options.target ? { target: options.target } : {}),
+        acted: true,
+        modalPending: true,
+        blockedState: "MODAL_STATE_BLOCKED",
+        diagnosticsDelta,
+        run,
+        ...(options.resultText ? maybeRawOutput(options.resultText) : {}),
+      },
+    };
+  })();
 }
 
 async function validateRefEpoch(options: {
@@ -194,6 +377,7 @@ async function assertFreshRefEpoch(options: { sessionName?: string; ref: string 
 export async function managedClick(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   semantic?: SemanticTarget;
   button?: string;
   sessionName?: string;
@@ -206,12 +390,36 @@ export async function managedClick(options: {
 
   if (options.semantic) {
     const target = normalizeSemanticTarget(options.semantic);
-    const result = await managedActionRunCode({
-      command: "click",
-      sessionName: options.sessionName,
-      source: semanticClickSource(target, options.button),
-    });
-    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
+    let result: Awaited<ReturnType<typeof managedActionRunCode>>;
+    try {
+      result = await managedActionRunCode({
+        command: "click",
+        sessionName: options.sessionName,
+        source: semanticClickSource(target, options.button),
+      });
+    } catch (error) {
+      if (isModalStateBlockedMessage(errorMessage(error))) {
+        return dialogPendingResult({
+          command: "click",
+          sessionName: options.sessionName,
+          target,
+          before,
+        });
+      }
+      await recordFailedRun("click", options.sessionName, undefined, before, error, { target });
+      throw error;
+    }
+    const diagnosticsDelta = await buildDiagnosticsDeltaOrSignal(options.sessionName, before);
+    if (isModalBlockedDelta(diagnosticsDelta)) {
+      return dialogPendingResult({
+        command: "click",
+        sessionName: options.sessionName,
+        page: result.page,
+        target,
+        before,
+        diagnosticsDelta,
+      });
+    }
     const run = await recordRun("click", options.sessionName, result.page, {
       target,
       diagnosticsDelta,
@@ -229,40 +437,55 @@ export async function managedClick(options: {
   }
 
   if (options.selector) {
-    const args = ["click", options.selector];
-    if (options.button) {
-      args.push(options.button);
-    }
-    const result = await runManagedSessionCommand(
-      {
-        _: args,
-      },
-      {
+    const target = normalizeSelectorTarget({ selector: options.selector, nth: options.nth });
+    const clickOptions = options.button ? JSON.stringify({ button: options.button }) : "undefined";
+    let result: Awaited<ReturnType<typeof managedActionRunCode>>;
+    try {
+      result = await managedActionRunCode({
+        command: "click",
         sessionName: options.sessionName,
-      },
-    );
-    throwIfManagedActionError(result.text, { command: "click", sessionName: options.sessionName });
-
-    const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const page = parsePageSummary(result.text);
-    const run = await recordRun("click", options.sessionName, page, {
-      target: { selector: options.selector },
+        source: selectorActionSource("CLICK", target, (locator) => {
+          return `await ${locator}.click(${clickOptions});`;
+        }),
+      });
+    } catch (error) {
+      if (isModalStateBlockedMessage(errorMessage(error))) {
+        return dialogPendingResult({
+          command: "click",
+          sessionName: options.sessionName,
+          target,
+          before,
+        });
+      }
+      await recordFailedRun("click", options.sessionName, undefined, before, error, { target });
+      throw error;
+    }
+    const diagnosticsDelta = await buildDiagnosticsDeltaOrSignal(options.sessionName, before);
+    if (isModalBlockedDelta(diagnosticsDelta)) {
+      return dialogPendingResult({
+        command: "click",
+        sessionName: options.sessionName,
+        page: result.page,
+        target,
+        before,
+        diagnosticsDelta,
+      });
+    }
+    const run = await recordRun("click", options.sessionName, result.page, {
+      target,
       diagnosticsDelta,
     });
     return {
-      session: {
-        scope: "managed",
-        name: result.sessionName,
-        default: result.sessionName === "default",
-      },
-      page,
+      session: result.session,
+      page: result.page,
       data: {
+        target,
         selector: options.selector,
+        nth: target.nth,
         ...(options.button ? { button: options.button } : {}),
         acted: true,
         diagnosticsDelta,
         run,
-        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -282,10 +505,37 @@ export async function managedClick(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command: "click", sessionName: options.sessionName });
+  const page = parsePageSummary(result.text);
+  try {
+    throwIfManagedActionError(result.text, { command: "click", sessionName: options.sessionName });
+  } catch (error) {
+    if (isModalStateBlockedMessage(errorMessage(error))) {
+      return dialogPendingResult({
+        command: "click",
+        sessionName: result.sessionName,
+        resultText: result.text,
+        page,
+        target: { ref },
+        before,
+      });
+    }
+    await recordFailedRun("click", result.sessionName, page, before, error, { target: { ref } });
+    throw error;
+  }
 
-  const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-  const run = await recordRun("click", options.sessionName, parsePageSummary(result.text), {
+  const diagnosticsDelta = await buildDiagnosticsDeltaOrSignal(options.sessionName, before);
+  if (isModalBlockedDelta(diagnosticsDelta)) {
+    return dialogPendingResult({
+      command: "click",
+      sessionName: result.sessionName,
+      resultText: result.text,
+      page,
+      target: { ref },
+      before,
+      diagnosticsDelta,
+    });
+  }
+  const run = await recordRun("click", options.sessionName, page, {
     target: options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector },
     diagnosticsDelta,
   });
@@ -295,7 +545,7 @@ export async function managedClick(options: {
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page,
     data: {
       ...(options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector }),
       acted: true,
@@ -311,6 +561,51 @@ function normalizeSemanticTarget(target: SemanticTarget) {
     ...target,
     nth: Math.max(1, Math.floor(Number(target.nth ?? 1))),
   };
+}
+
+function normalizeSelectorTarget(target: SelectorTarget) {
+  return {
+    selector: target.selector,
+    nth: Math.max(1, Math.floor(Number(target.nth ?? 1))),
+  };
+}
+
+function selectorActionSource(
+  errorPrefix: string,
+  target: ReturnType<typeof normalizeSelectorTarget>,
+  actionSource: (locatorExpression: string) => string,
+) {
+  const nthIndex = target.nth - 1;
+  const targetJson = JSON.stringify(target);
+  const locatorExpression = `page.locator(${JSON.stringify(target.selector)})`;
+  const action = actionSource(`locator.nth(${nthIndex})`);
+
+  return `async page => {
+    const target = ${targetJson};
+    const locator = ${locatorExpression};
+    const count = await locator.count();
+    if (count === 0) {
+      throw new Error(
+        '${errorPrefix}_SELECTOR_NOT_FOUND:' +
+          JSON.stringify({ target })
+      );
+    }
+    if (${nthIndex} >= count) {
+      throw new Error(
+        '${errorPrefix}_SELECTOR_INDEX_OUT_OF_RANGE:' +
+          JSON.stringify({ target, count, nth: ${target.nth} })
+      );
+    }
+    ${action}
+    return JSON.stringify({
+      acted: true,
+      selected: ${errorPrefix === "SELECT" ? "true" : "undefined"},
+      values: typeof values === 'undefined' ? undefined : values,
+      target,
+      count,
+      nth: ${target.nth},
+    });
+  }`;
 }
 
 function semanticLocatorExpression(target: ReturnType<typeof normalizeSemanticTarget>) {
@@ -394,6 +689,7 @@ function semanticInputSource(
 export async function managedFill(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   semantic?: SemanticTarget;
   value: string;
   sessionName?: string;
@@ -406,10 +702,12 @@ export async function managedFill(options: {
 
   if (options.semantic) {
     const target = normalizeSemanticTarget(options.semantic);
-    const result = await managedActionRunCode({
+    const result = await managedActionRunCodeWithFailureRun({
       command: "fill",
       sessionName: options.sessionName,
       source: semanticInputSource("FILL", target, "fill", options.value),
+      before,
+      target,
     });
 
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
@@ -431,36 +729,32 @@ export async function managedFill(options: {
   }
 
   if (options.selector) {
-    const result = await runManagedSessionCommand(
-      {
-        _: ["fill", options.selector, options.value],
-      },
-      {
-        sessionName: options.sessionName,
-      },
-    );
-    throwIfManagedActionError(result.text, { command: "fill", sessionName: options.sessionName });
-
+    const target = normalizeSelectorTarget({ selector: options.selector, nth: options.nth });
+    const result = await managedActionRunCodeWithFailureRun({
+      command: "fill",
+      sessionName: options.sessionName,
+      source: selectorActionSource("FILL", target, (locator) => {
+        return `await ${locator}.fill(${JSON.stringify(options.value)});`;
+      }),
+      before,
+      target,
+    });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const page = parsePageSummary(result.text);
-    const run = await recordRun("fill", options.sessionName, page, {
-      target: { selector: options.selector },
+    const run = await recordRun("fill", options.sessionName, result.page, {
+      target,
       diagnosticsDelta,
     });
     return {
-      session: {
-        scope: "managed",
-        name: result.sessionName,
-        default: result.sessionName === "default",
-      },
-      page,
+      session: result.session,
+      page: result.page,
       data: {
+        target,
         selector: options.selector,
+        nth: target.nth,
         value: options.value,
         filled: true,
         diagnosticsDelta,
         run,
-        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -477,10 +771,15 @@ export async function managedFill(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command: "fill", sessionName: options.sessionName });
+  const fillPage = parsePageSummary(result.text);
+  await throwIfManagedActionErrorWithFailureRun(
+    result.text,
+    { command: "fill", sessionName: options.sessionName },
+    { before, page: fillPage, target: { ref: normalizeRef(options.ref ?? "") } },
+  );
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-  const run = await recordRun("fill", options.sessionName, parsePageSummary(result.text), {
+  const run = await recordRun("fill", options.sessionName, fillPage, {
     target: options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector },
     diagnosticsDelta,
   });
@@ -490,7 +789,7 @@ export async function managedFill(options: {
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page: fillPage,
     data: {
       ...(options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector }),
       value: options.value,
@@ -505,6 +804,7 @@ export async function managedFill(options: {
 export async function managedType(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   semantic?: SemanticTarget;
   value: string;
   sessionName?: string;
@@ -513,10 +813,12 @@ export async function managedType(options: {
 
   if (options.semantic) {
     const target = normalizeSemanticTarget(options.semantic);
-    const result = await managedActionRunCode({
+    const result = await managedActionRunCodeWithFailureRun({
       command: "type",
       sessionName: options.sessionName,
       source: semanticInputSource("TYPE", target, "type", options.value),
+      before,
+      target,
     });
 
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
@@ -546,9 +848,14 @@ export async function managedType(options: {
         sessionName: options.sessionName,
       },
     );
-    throwIfManagedActionError(result.text, { command: "type", sessionName: options.sessionName });
+    const page = parsePageSummary(result.text);
+    await throwIfManagedActionErrorWithFailureRun(
+      result.text,
+      { command: "type", sessionName: options.sessionName },
+      { before, page },
+    );
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const run = await recordRun("type", options.sessionName, parsePageSummary(result.text), {
+    const run = await recordRun("type", options.sessionName, page, {
       diagnosticsDelta,
     });
     return {
@@ -557,7 +864,7 @@ export async function managedType(options: {
         name: result.sessionName,
         default: result.sessionName === "default",
       },
-      page: parsePageSummary(result.text),
+      page,
       data: {
         value: options.value,
         typed: true,
@@ -572,25 +879,38 @@ export async function managedType(options: {
   if (options.ref) {
     await assertFreshRefEpoch({ sessionName: options.sessionName, ref: target ?? "" });
   }
+  const selectorTarget = options.selector
+    ? normalizeSelectorTarget({ selector: options.selector, nth: options.nth })
+    : undefined;
   const source = options.ref
     ? `async page => { await page.locator(${JSON.stringify(`aria-ref=${target}`)}).type(${JSON.stringify(options.value)}); return 'typed'; }`
-    : `async page => { await page.locator(${JSON.stringify(options.selector)}).type(${JSON.stringify(options.value)}); return 'typed'; }`;
+    : selectorActionSource(
+        "TYPE",
+        selectorTarget as ReturnType<typeof normalizeSelectorTarget>,
+        (locator) => {
+          return `await ${locator}.type(${JSON.stringify(options.value)});`;
+        },
+      );
 
-  const result = await managedActionRunCode({
+  const result = await managedActionRunCodeWithFailureRun({
     command: "type",
     source,
     sessionName: options.sessionName,
+    before,
+    target: options.ref ? { ref: normalizeRef(options.ref) } : selectorTarget,
   });
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("type", options.sessionName, result.page, {
-    target: options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector },
+    target: options.ref ? { ref: normalizeRef(options.ref) } : selectorTarget,
     diagnosticsDelta,
   });
   return {
     session: result.session,
     page: result.page,
     data: {
-      ...(options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector }),
+      ...(options.ref
+        ? { ref: normalizeRef(options.ref) }
+        : { target: selectorTarget, selector: options.selector, nth: selectorTarget?.nth }),
       value: options.value,
       typed: true,
       diagnosticsDelta,
@@ -610,10 +930,15 @@ export async function managedPress(key: string, options?: { sessionName?: string
       sessionName: options?.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command: "press", sessionName: options?.sessionName });
+  const page = parsePageSummary(result.text);
+  await throwIfManagedActionErrorWithFailureRun(
+    result.text,
+    { command: "press", sessionName: options?.sessionName },
+    { before, page, details: { key } },
+  );
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options?.sessionName, before);
-  const run = await recordRun("press", options?.sessionName, parsePageSummary(result.text), {
+  const run = await recordRun("press", options?.sessionName, page, {
     key,
     diagnosticsDelta,
   });
@@ -623,7 +948,7 @@ export async function managedPress(key: string, options?: { sessionName?: string
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page,
     data: {
       key,
       pressed: true,
@@ -639,6 +964,7 @@ async function managedBooleanControlAction(
   options: {
     ref?: string;
     selector?: string;
+    nth?: number;
     sessionName?: string;
   },
 ) {
@@ -649,35 +975,32 @@ async function managedBooleanControlAction(
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await runManagedSessionCommand(
-      {
-        _: [command, options.selector],
-      },
-      {
-        sessionName: options.sessionName,
-      },
-    );
-    throwIfManagedActionError(result.text, { command, sessionName: options.sessionName });
+    const target = normalizeSelectorTarget({ selector: options.selector, nth: options.nth });
+    const result = await managedActionRunCodeWithFailureRun({
+      command,
+      sessionName: options.sessionName,
+      source: selectorActionSource(command.toUpperCase(), target, (locator) => {
+        return `await ${locator}.${command}();`;
+      }),
+      before,
+      target,
+    });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const page = parsePageSummary(result.text);
-    const run = await recordRun(command, options.sessionName, page, {
-      target: { selector: options.selector },
+    const run = await recordRun(command, options.sessionName, result.page, {
+      target,
       diagnosticsDelta,
     });
     return {
-      session: {
-        scope: "managed",
-        name: result.sessionName,
-        default: result.sessionName === "default",
-      },
-      page,
+      session: result.session,
+      page: result.page,
       data: {
+        target,
         selector: options.selector,
+        nth: target.nth,
         acted: true,
         checked: command === "check",
         diagnosticsDelta,
         run,
-        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -692,10 +1015,15 @@ async function managedBooleanControlAction(
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command, sessionName: options.sessionName });
+  const page = parsePageSummary(result.text);
+  await throwIfManagedActionErrorWithFailureRun(
+    result.text,
+    { command, sessionName: options.sessionName },
+    { before, page, target: { ref } },
+  );
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-  const run = await recordRun(command, options.sessionName, parsePageSummary(result.text), {
+  const run = await recordRun(command, options.sessionName, page, {
     target: { ref },
     diagnosticsDelta,
   });
@@ -705,7 +1033,7 @@ async function managedBooleanControlAction(
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page,
     data: {
       ref,
       acted: true,
@@ -720,6 +1048,7 @@ async function managedBooleanControlAction(
 export async function managedCheck(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   sessionName?: string;
 }) {
   return managedBooleanControlAction("check", options);
@@ -728,6 +1057,7 @@ export async function managedCheck(options: {
 export async function managedHover(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   sessionName?: string;
 }) {
   if (!options.ref && !options.selector) {
@@ -737,34 +1067,31 @@ export async function managedHover(options: {
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await runManagedSessionCommand(
-      {
-        _: ["hover", options.selector],
-      },
-      {
-        sessionName: options.sessionName,
-      },
-    );
-    throwIfManagedActionError(result.text, { command: "hover", sessionName: options.sessionName });
+    const target = normalizeSelectorTarget({ selector: options.selector, nth: options.nth });
+    const result = await managedActionRunCodeWithFailureRun({
+      command: "hover",
+      sessionName: options.sessionName,
+      source: selectorActionSource("HOVER", target, (locator) => {
+        return `await ${locator}.hover();`;
+      }),
+      before,
+      target,
+    });
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-    const page = parsePageSummary(result.text);
-    const run = await recordRun("hover", options.sessionName, page, {
-      target: { selector: options.selector },
+    const run = await recordRun("hover", options.sessionName, result.page, {
+      target,
       diagnosticsDelta,
     });
     return {
-      session: {
-        scope: "managed",
-        name: result.sessionName,
-        default: result.sessionName === "default",
-      },
-      page,
+      session: result.session,
+      page: result.page,
       data: {
+        target,
         selector: options.selector,
+        nth: target.nth,
         acted: true,
         diagnosticsDelta,
         run,
-        ...maybeRawOutput(result.text),
       },
     };
   }
@@ -779,10 +1106,15 @@ export async function managedHover(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command: "hover", sessionName: options.sessionName });
+  const page = parsePageSummary(result.text);
+  await throwIfManagedActionErrorWithFailureRun(
+    result.text,
+    { command: "hover", sessionName: options.sessionName },
+    { before, page, target: { ref } },
+  );
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-  const run = await recordRun("hover", options.sessionName, parsePageSummary(result.text), {
+  const run = await recordRun("hover", options.sessionName, page, {
     target: { ref },
     diagnosticsDelta,
   });
@@ -792,7 +1124,7 @@ export async function managedHover(options: {
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page,
     data: {
       ref,
       acted: true,
@@ -806,6 +1138,7 @@ export async function managedHover(options: {
 export async function managedUncheck(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   sessionName?: string;
 }) {
   return managedBooleanControlAction("uncheck", options);
@@ -814,6 +1147,7 @@ export async function managedUncheck(options: {
 export async function managedSelect(options: {
   ref?: string;
   selector?: string;
+  nth?: number;
   sessionName?: string;
   value: string;
 }) {
@@ -824,19 +1158,22 @@ export async function managedSelect(options: {
   const before = await captureDiagnosticsBaseline(options.sessionName);
 
   if (options.selector) {
-    const result = await managedActionRunCode({
+    const target = normalizeSelectorTarget({ selector: options.selector, nth: options.nth });
+    const result = await managedActionRunCodeWithFailureRun({
       command: "select",
       sessionName: options.sessionName,
-      source: `async page => {
-        const values = await page.locator(${JSON.stringify(options.selector)}).selectOption(${JSON.stringify(options.value)});
-        return JSON.stringify({ selected: true, values });
-      }`,
+      source: selectorActionSource("SELECT", target, (locator) => {
+        return `const values = await ${locator}.selectOption(${JSON.stringify(options.value)});`;
+      }),
+      before,
+      target,
+      details: { value: options.value },
     });
     const parsed =
       typeof result.data.result === "object" && result.data.result ? result.data.result : {};
     const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
     const run = await recordRun("select", options.sessionName, result.page, {
-      target: { selector: options.selector },
+      target,
       value: options.value,
       diagnosticsDelta,
     });
@@ -844,7 +1181,9 @@ export async function managedSelect(options: {
       session: result.session,
       page: result.page,
       data: {
+        target,
         selector: options.selector,
+        nth: target.nth,
         value: options.value,
         values: Array.isArray(parsed.values) ? parsed.values : [options.value],
         selected: true,
@@ -864,10 +1203,15 @@ export async function managedSelect(options: {
       sessionName: options.sessionName,
     },
   );
-  throwIfManagedActionError(result.text, { command: "select", sessionName: options.sessionName });
+  const page = parsePageSummary(result.text);
+  await throwIfManagedActionErrorWithFailureRun(
+    result.text,
+    { command: "select", sessionName: options.sessionName },
+    { before, page, target: { ref }, details: { value: options.value } },
+  );
 
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
-  const run = await recordRun("select", options.sessionName, parsePageSummary(result.text), {
+  const run = await recordRun("select", options.sessionName, page, {
     target: { ref },
     value: options.value,
     diagnosticsDelta,
@@ -878,7 +1222,7 @@ export async function managedSelect(options: {
       name: result.sessionName,
       default: result.sessionName === "default",
     },
-    page: parsePageSummary(result.text),
+    page,
     data: {
       ref,
       value: options.value,
@@ -1072,23 +1416,84 @@ export async function managedUpload(options: {
   if (options.ref) {
     await assertFreshRefEpoch({ sessionName: options.sessionName, ref: normalizeRef(options.ref) });
   }
-  const files = options.files.map((file) => JSON.stringify(resolve(file))).join(", ");
+  const resolvedFiles = options.files.map((file) => resolve(file));
+  const files = resolvedFiles.map((file) => JSON.stringify(file)).join(", ");
   const target = options.ref
     ? `page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.ref)}`)})`
     : `page.locator(${JSON.stringify(options.selector)})`;
+  const uploadSignalToken = `pwcli-upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
   const result = await managedRunCode({
     sessionName: options.sessionName,
     source: `async page => {
-      await ${target}.setInputFiles([${files}]);
-      return JSON.stringify({ uploaded: true });
+      const locator = ${target};
+      const token = ${JSON.stringify(uploadSignalToken)};
+      await locator.evaluate((element, token) => {
+        const win = element.ownerDocument.defaultView;
+        if (!win)
+          return;
+        const state = win.__pwcliUploadSignals ||= {};
+        state[token] = { changeObserved: false, inputObserved: false };
+        element.addEventListener('change', () => {
+          state[token].changeObserved = true;
+        }, { once: true });
+        element.addEventListener('input', () => {
+          state[token].inputObserved = true;
+        }, { once: true });
+      }, token);
+      await locator.setInputFiles([${files}]);
+      await page.waitForFunction(token => {
+        const state = window.__pwcliUploadSignals?.[token];
+        return Boolean(state?.changeObserved || state?.inputObserved);
+      }, token, { timeout: 750 }).catch(() => null);
+      const settle = await locator.evaluate((element, payload) => {
+        const input = element instanceof HTMLInputElement
+          ? element
+          : element.querySelector('input[type="file"]');
+        const state = element.ownerDocument.defaultView?.__pwcliUploadSignals?.[payload.token] ?? {};
+        const fileCount = input?.files?.length ?? null;
+        const fileNames = input?.files ? Array.from(input.files).map(file => file.name) : [];
+        return {
+          fileCount,
+          fileNames,
+          expectedCount: payload.expectedCount,
+          changeObserved: Boolean(state.changeObserved),
+          inputObserved: Boolean(state.inputObserved),
+          filesMatch: fileCount === payload.expectedCount,
+        };
+      }, { token, expectedCount: ${resolvedFiles.length} });
+      const settled = Boolean(settle.filesMatch && (settle.changeObserved || settle.inputObserved));
+      return JSON.stringify({
+        uploaded: true,
+        settle: { ...settle, settled },
+        nextSteps: settled ? [] : [
+          'Run \`pw wait --session <name> --selector <uploaded-state-selector>\` or \`pw wait --session <name> --response <upload-api>\`',
+          'Verify the page accepted the upload with \`pw verify\`, \`pw get\`, or \`pw read-text\`, then retry if needed',
+        ],
+      });
     }`,
   });
+  const parsed =
+    typeof result.data.result === "object" && result.data.result ? result.data.result : {};
+  const settle =
+    "settle" in parsed && parsed.settle && typeof parsed.settle === "object"
+      ? (parsed.settle as Record<string, unknown>)
+      : {
+          settled: false,
+          fileCount: null,
+          expectedCount: resolvedFiles.length,
+          changeObserved: false,
+          inputObserved: false,
+          filesMatch: false,
+        };
+  const nextSteps = Array.isArray(parsed.nextSteps) ? parsed.nextSteps : [];
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("upload", options.sessionName, result.page, {
     target: options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector },
-    files: options.files.map((file) => resolve(file)),
+    files: resolvedFiles,
+    settle,
+    nextSteps,
     diagnosticsDelta,
   });
   return {
@@ -1096,8 +1501,10 @@ export async function managedUpload(options: {
     page: result.page,
     data: {
       ...(options.ref ? { ref: normalizeRef(options.ref) } : { selector: options.selector }),
-      files: options.files.map((file) => resolve(file)),
+      files: resolvedFiles,
       uploaded: true,
+      settle,
+      ...(nextSteps.length > 0 ? { nextSteps } : {}),
       diagnosticsDelta,
       run,
     },
@@ -1339,10 +1746,17 @@ export async function managedWait(options: {
   sessionName?: string;
 }) {
   let source = "";
+  let condition: Record<string, unknown> | string = "";
 
   if (options.target && /^\d+$/.test(options.target)) {
+    condition = { kind: "delay", timeoutMs: Number(options.target) };
     source = `async page => { await page.waitForTimeout(${Number(options.target)}); return 'delay'; }`;
   } else if (options.request) {
+    condition = {
+      kind: "request",
+      url: options.request,
+      ...(options.method ? { method: options.method.toUpperCase() } : {}),
+    };
     source = `async page => {
       const request = await page.waitForRequest(request => {
         if (!request.url().includes(${JSON.stringify(options.request)}))
@@ -1353,6 +1767,12 @@ export async function managedWait(options: {
       return JSON.stringify({ kind: 'request', url: request.url(), method: request.method() });
     }`;
   } else if (options.response) {
+    condition = {
+      kind: "response",
+      url: options.response,
+      ...(options.method ? { method: options.method.toUpperCase() } : {}),
+      ...(options.status ? { status: options.status } : {}),
+    };
     source = `async page => {
       const response = await page.waitForResponse(response => {
         if (!response.url().includes(${JSON.stringify(options.response)}))
@@ -1364,21 +1784,32 @@ export async function managedWait(options: {
       return JSON.stringify({ kind: 'response', url: response.url(), method: response.request().method(), status: response.status() });
     }`;
   } else if (options.networkidle) {
+    condition = { kind: "networkidle" };
     source = `async page => { await page.waitForLoadState('networkidle'); return 'networkidle'; }`;
   } else if (options.selector) {
+    condition = { kind: "selector", selector: options.selector };
     source = `async page => { await page.locator(${JSON.stringify(options.selector)}).waitFor(); return 'selector'; }`;
   } else if (options.text) {
+    condition = { kind: "text", text: options.text };
     source = `async page => { await page.getByText(${JSON.stringify(options.text)}, { exact: true }).waitFor(); return 'text'; }`;
   } else if (options.target) {
+    condition = { kind: "ref", ref: normalizeRef(options.target) };
     source = `async page => { await page.locator(${JSON.stringify(`aria-ref=${normalizeRef(options.target)}`)}).waitFor(); return 'ref'; }`;
   } else {
     throw new Error("wait requires a condition");
   }
 
   const before = await captureDiagnosticsBaseline(options.sessionName);
-  const result = await managedRunCode({ source, sessionName: options.sessionName });
+  let result: Awaited<ReturnType<typeof managedRunCode>>;
+  try {
+    result = await managedRunCode({ source, sessionName: options.sessionName });
+  } catch (error) {
+    await recordFailedRun("wait", options.sessionName, undefined, before, error, { condition });
+    throw error;
+  }
   const diagnosticsDelta = await buildDiagnosticsDelta(options.sessionName, before);
   const run = await recordRun("wait", options.sessionName, result.page, {
+    condition,
     diagnosticsDelta,
   });
 

--- a/src/infra/playwright/runtime/state-checks.ts
+++ b/src/infra/playwright/runtime/state-checks.ts
@@ -41,6 +41,12 @@ type StateCandidate = {
   text: string;
   tagName: string;
   visible: boolean;
+  href?: string;
+  role?: string;
+  name?: string;
+  ancestor?: string;
+  region?: string;
+  selectorHint?: string;
 };
 
 function targetExpression(target: StateTarget) {
@@ -104,6 +110,12 @@ function parsedCandidates(value: unknown): StateCandidate[] {
           text: typeof record.text === "string" ? record.text : "",
           tagName: typeof record.tagName === "string" ? record.tagName : "",
           visible: Boolean(record.visible),
+          href: typeof record.href === "string" ? record.href : undefined,
+          role: typeof record.role === "string" ? record.role : undefined,
+          name: typeof record.name === "string" ? record.name : undefined,
+          ancestor: typeof record.ancestor === "string" ? record.ancestor : undefined,
+          region: typeof record.region === "string" ? record.region : undefined,
+          selectorHint: typeof record.selectorHint === "string" ? record.selectorHint : undefined,
         };
       })
     : [];
@@ -118,13 +130,114 @@ export async function managedLocate(options: { sessionName?: string; target: Sta
       const nth = typeof target.nth === 'number' ? Math.max(1, Math.floor(target.nth)) : null;
       const count = await locator.count();
       const candidates = await locator.evaluateAll((nodes, nth) => {
+        const cleanText = value => (value || '').replace(/\\s+/g, ' ').trim();
+        const cssEscape = value =>
+          globalThis.CSS && typeof globalThis.CSS.escape === 'function'
+            ? globalThis.CSS.escape(value)
+            : String(value).replace(/[^a-zA-Z0-9_-]/g, '\\\\$&');
+        const attr = (node, name) => node.getAttribute(name) || '';
+        const roleOf = node => {
+          const explicit = attr(node, 'role');
+          if (explicit) return explicit;
+          const tag = node.tagName.toLowerCase();
+          if (tag === 'a' && attr(node, 'href')) return 'link';
+          if (tag === 'button') return 'button';
+          if (tag === 'select') return 'combobox';
+          if (tag === 'textarea') return 'textbox';
+          if (tag === 'img') return 'img';
+          if (tag === 'input') {
+            const type = attr(node, 'type').toLowerCase() || 'text';
+            if (type === 'checkbox' || type === 'radio') return type;
+            if (['button', 'submit', 'reset'].includes(type)) return 'button';
+            if (type === 'range') return 'slider';
+            if (type === 'number') return 'spinbutton';
+            if (type === 'search') return 'searchbox';
+            return 'textbox';
+          }
+          if (tag === 'main') return 'main';
+          if (tag === 'nav') return 'navigation';
+          if (tag === 'form') return 'form';
+          return '';
+        };
+        const labelledByName = node =>
+          attr(node, 'aria-labelledby')
+            .split(/\\s+/)
+            .map(id => cleanText(node.ownerDocument.getElementById(id)?.textContent || ''))
+            .filter(Boolean)
+            .join(' ');
+        const nameOf = node =>
+          cleanText(
+            attr(node, 'aria-label') ||
+              labelledByName(node) ||
+              attr(node, 'alt') ||
+              attr(node, 'title') ||
+              (node instanceof HTMLInputElement ? node.value : '') ||
+              node.textContent ||
+              '',
+          ).slice(0, 120);
+        const selectorPart = node => {
+          const tag = node.tagName.toLowerCase();
+          if (node.id) return '#' + cssEscape(node.id);
+          for (const name of ['data-testid', 'data-test-id', 'name', 'aria-label']) {
+            const value = attr(node, name);
+            if (value) return tag + '[' + name + '="' + value.replace(/"/g, '\\\\"') + '"]';
+          }
+          const classHint = [...node.classList]
+            .filter(item => /^[a-zA-Z0-9_-]+$/.test(item))
+            .slice(0, 2)
+            .map(item => '.' + cssEscape(item))
+            .join('');
+          if (classHint) return tag + classHint;
+          if (!node.parentElement) return tag;
+          const siblings = [...node.parentElement.children].filter(
+            item => item.tagName === node.tagName,
+          );
+          const position = siblings.indexOf(node) + 1;
+          return siblings.length > 1 ? tag + ':nth-of-type(' + position + ')' : tag;
+        };
+        const selectorHintOf = node => {
+          const parts = [];
+          let current = node;
+          while (current && current.nodeType === Node.ELEMENT_NODE && parts.length < 4) {
+            parts.unshift(selectorPart(current));
+            if (current.id) break;
+            current = current.parentElement;
+          }
+          return parts.join(' > ');
+        };
+        const describe = node => {
+          const role = roleOf(node);
+          const name = nameOf(node);
+          const selector = selectorPart(node);
+          return [
+            node.tagName.toLowerCase(),
+            role ? 'role=' + JSON.stringify(role) : '',
+            name ? 'name=' + JSON.stringify(name) : '',
+            selector ? 'selector=' + JSON.stringify(selector) : '',
+          ].filter(Boolean).join(' ');
+        };
+        const regionOf = node => {
+          const region = node.closest(
+            '[role="region"], [role="banner"], [role="main"], [role="navigation"], [role="complementary"], [role="contentinfo"], [role="search"], main, nav, aside, header, footer, section[aria-label], form[aria-label]',
+          );
+          return region && region !== node ? describe(region) : '';
+        };
         const selected = nth ? nodes.slice(nth - 1, nth) : nodes.slice(0, 10);
-        return selected.map((node, index) => ({
-          index: nth ? nth : index + 1,
-          text: (node.textContent || '').trim().slice(0, 160),
-          tagName: node.tagName.toLowerCase(),
-          visible: !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length),
-        }));
+        return selected.map((node, index) => {
+          const anchor = node.closest('a[href]');
+          return {
+            index: nth ? nth : index + 1,
+            text: cleanText(node.textContent).slice(0, 160),
+            tagName: node.tagName.toLowerCase(),
+            visible: !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length),
+            href: anchor ? anchor.href : '',
+            role: roleOf(node),
+            name: nameOf(node),
+            ancestor: node.parentElement ? describe(node.parentElement) : '',
+            region: regionOf(node),
+            selectorHint: selectorHintOf(node),
+          };
+        });
       }, nth);
       return JSON.stringify({ count, candidates });
     }`,


### PR DESCRIPTION
@codex please review

## Summary
- fix Forge/DC auth target resolution and remove raw provider args from auth output
- apply selector --nth consistently across action commands and enrich locate candidates
- record failed actions/waits in diagnostics, distinguish dialog-pending click success, and add per-session command locking
- stabilize upload settle signals, add trace artifact paths, and support --download-dir
- update pwcli skill/docs for large snapshots, search challenges, content-reading diagnostics noise, and targeted validation policy

## Issues
Fixes #55
Fixes #56
Fixes #57
Fixes #58
Fixes #59
Fixes #60
Fixes #61
Fixes #62
Fixes #63
Fixes #64
Fixes #65
Fixes #66

## Verification
- pnpm build
- pnpm exec biome check $(git diff --name-only --diff-filter=ACM | tr "\n" " ")
- pnpm exec tsx scripts/test/diagnostics-failure-run.test.ts
- pw auth info dc --output json
- pw click selector --nth real session check
- pw dialog pending click + diagnostics runs + dialog accept
- pw failed click + diagnostics runs
- pw locate duplicate text metadata check
- pw upload settle + get text + download --download-dir
- pw trace start/stop artifact path check

No full smoke run per current project validation policy.