### PR TITLE
feat: --snap-diff — action 后返回无障碍树增量 diff

### DIFF
--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -87,6 +87,40 @@ pw verify text -s explore-a --text '<expected-text>'
 
 规则：动作成功不等于任务成功。动作后必须等待和验证。
 
+### 增量快照 diff
+
+执行动作后用 `--snap-diff`（alias `--diff`）返回无障碍树增量变化：
+
+```bash
+pw snapshot -i -s explore-a                    # 建立基线（缓存自动存入 browser-side state）
+pw click e5 -s explore-a --diff                # click 后返回 diff：[+] 新增 [~] 变化 removed
+pw fill e3 "hello" -s explore-a --diff          # fill 后返回 diff
+pw select e8 "US" -s explore-a --diff           # select 后返回 diff
+```
+
+支持 `--diff` 的命令：`click`、`fill`、`type`、`hover`、`select`、`check`、`uncheck`。
+
+diff 输出格式：
+
+```
+fill filled=true
+page /login (Login)
+
+# snap-diff: +1 ~1 -0
+- link "Home" [ref=e0]
+- textbox [ref=e3]:
+  - text: "hello" [~]
+- button "Submit" [ref=e5]
+# removed: e88
+```
+
+规则：
+
+- 必须先执行一次 `snapshot` 建立基线，否则 diff 为空。
+- diff 是 best-effort：失败不影响 action 本身的成功/失败状态。
+- 基线缓存在 browser-side state，session 关闭即丢。
+- 多步流程中每步 `--diff` 的基线是上一步 diff 后的快照，无需手动刷新。
+
 ### Semantic intent
 
 看到明显的提交按钮、cookie 横幅、关闭弹窗、下一页这类高频语义目标时，可以先用：

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -31,6 +31,9 @@ export const sharedArgs = { ...sessionArg, ...outputArg } as const;
 export const actionArgs = {
   ...sharedArgs,
   ...locatorArgs,
+} as const;
+export const interactiveActionArgs = {
+  ...actionArgs,
   "snap-diff": {
     type: "boolean",
     description: "Return accessibility tree diff after action",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -28,4 +28,12 @@ export const locatorArgs = {
 } as const;
 
 export const sharedArgs = { ...sessionArg, ...outputArg } as const;
-export const actionArgs = { ...sharedArgs, ...locatorArgs } as const;
+export const actionArgs = {
+  ...sharedArgs,
+  ...locatorArgs,
+  "snap-diff": {
+    type: "boolean",
+    description: "Return accessibility tree diff after action",
+    alias: ["diff"],
+  },
+} as const;

--- a/src/cli/commands/_helpers.ts
+++ b/src/cli/commands/_helpers.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { buildSemanticTarget, parseNth, parseStateTarget } from "#cli/parsers/target.js";
 import type { SemanticTarget } from "#engine/act/element.js";
+import { computePostActionDiff } from "#engine/snapshot-diff.js";
 import { printCommandError, printCommandResult } from "../output.js";
 import { printSessionAwareCommandError, requireSessionName } from "../parsers/session.js";
 
@@ -95,4 +96,16 @@ export async function sourceFromArgs(source: string | undefined, file: string | 
 
 export function semanticOnly(args: CliArgs): SemanticTarget | undefined {
   return buildSemanticTarget(args as Parameters<typeof buildSemanticTarget>[0]);
+}
+
+export async function attachSnapDiff(
+  sessionName: string | undefined,
+  result: { data: Record<string, unknown> },
+) {
+  try {
+    const diff = await computePostActionDiff(sessionName);
+    if (diff) result.data.snapshotDiff = diff;
+  } catch {
+    // snap-diff is best-effort; don't fail the action
+  }
 }

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedCheck } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: check a checkbox or radio control by ref, selector, or semantic locator.\nExamples:\n  pw check -s task-a --label 'I agree'\n  pw check -s task-a --selector '#terms'\nNotes: use `is checked` afterward when the checked state matters. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,23 +1,31 @@
 import { defineCommand } from "citty";
 import { actionArgs } from "#cli/args.js";
 import { managedCheck } from "#engine/act/element.js";
-import { actionTarget, type CliArgs, firstPos, print, session, withCliError } from "./_helpers.js";
+import {
+  actionTarget,
+  attachSnapDiff,
+  bool,
+  type CliArgs,
+  firstPos,
+  print,
+  session,
+  withCliError,
+} from "./_helpers.js";
 
 export default defineCommand({
   meta: {
     name: "check",
     description:
-      "Purpose: check a checkbox or radio control by ref, selector, or semantic locator.\nExamples:\n  pw check -s task-a --label 'I agree'\n  pw check -s task-a --selector '#terms'\nNotes: use `is checked` afterward when the checked state matters.",
+      "Purpose: check a checkbox or radio control by ref, selector, or semantic locator.\nExamples:\n  pw check -s task-a --label 'I agree'\n  pw check -s task-a --selector '#terms'\nNotes: use `is checked` afterward when the checked state matters. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {
-      print(
-        "check",
-        await managedCheck({ sessionName: session(a), ...actionTarget(a, firstPos(a)) }),
-        a,
-      );
+      const sessionName = session(a);
+      const result = await managedCheck({ sessionName, ...actionTarget(a, firstPos(a)) });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
+      print("check", result, a);
     } catch (error) {
       withCliError("check", a, error, "check failed");
     }

--- a/src/cli/commands/click.ts
+++ b/src/cli/commands/click.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedClick } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -19,7 +19,7 @@ export default defineCommand({
       "Purpose: click an element by ref, selector, or semantic locator.\nExamples:\n  pw click -s task-a --text Submit\n  pw click -s task-a --ref e12\n  pw click -s task-a --ref e12 --diff\nNotes: follow clicks with `wait` and a read-only verification command. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: {
-    ...actionArgs,
+    ...interactiveActionArgs,
     button: {
       type: "enum",
       options: ["left", "right", "middle"],

--- a/src/cli/commands/click.ts
+++ b/src/cli/commands/click.ts
@@ -1,13 +1,22 @@
 import { defineCommand } from "citty";
 import { actionArgs } from "#cli/args.js";
 import { managedClick } from "#engine/act/element.js";
-import { actionTarget, type CliArgs, firstPos, print, session, withCliError } from "./_helpers.js";
+import {
+  actionTarget,
+  attachSnapDiff,
+  bool,
+  type CliArgs,
+  firstPos,
+  print,
+  session,
+  withCliError,
+} from "./_helpers.js";
 
 export default defineCommand({
   meta: {
     name: "click",
     description:
-      "Purpose: click an element by ref, selector, or semantic locator.\nExamples:\n  pw click -s task-a --text Submit\n  pw click -s task-a --ref e12\nNotes: follow clicks with `wait` and a read-only verification command.",
+      "Purpose: click an element by ref, selector, or semantic locator.\nExamples:\n  pw click -s task-a --text Submit\n  pw click -s task-a --ref e12\n  pw click -s task-a --ref e12 --diff\nNotes: follow clicks with `wait` and a read-only verification command. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: {
     ...actionArgs,
@@ -27,6 +36,7 @@ export default defineCommand({
         ...actionTarget(a, firstPos(a)),
         button: a.button !== "left" ? (a.button as string) : undefined,
       });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
       print("click", result, a);
     } catch (error) {
       withCliError("click", a, error, "click failed");

--- a/src/cli/commands/code.ts
+++ b/src/cli/commands/code.ts
@@ -18,7 +18,7 @@ export default defineCommand({
   meta: {
     name: "code",
     description:
-      "Purpose: run a short Playwright page-context escape hatch in an existing session.\nOptions: pass inline source as the positional argument or use --file.\nExamples:\n  pw code -s task-a 'return await page.title()'\n  pw code -s task-a --file ./probe.js\nNotes: do not use code as a long workflow runner; prefer first-class commands plus explicit wait/verify steps.",
+      "Purpose: run a short Playwright page-context escape hatch in an existing session.\nOptions: pass inline source as the positional argument or use --file. Use --timeout to extend the guard limit for long operations.\nExamples:\n  pw code -s task-a 'return await page.title()'\n  pw code -s task-a --file ./probe.js --timeout 120000\nNotes: do not use code as a long workflow runner; prefer first-class commands plus explicit wait/verify steps.",
   },
   args: {
     ...sharedArgs,
@@ -28,6 +28,12 @@ export default defineCommand({
       valueHint: "path",
     },
     retry: { type: "string", description: "Retry count", default: "0", valueHint: "n" },
+    timeout: {
+      type: "string",
+      description: "Execution timeout in milliseconds",
+      default: "60000",
+      valueHint: "ms",
+    },
   },
   async run({ args }) {
     const a = args as CliArgs;
@@ -41,6 +47,7 @@ export default defineCommand({
           sessionName,
           source: (await sourceFromArgs(firstPos(a), str(a.file))) ?? "",
           retry: num(a.retry, 0),
+          timeoutMs: num(a.timeout, 60_000),
         }),
         a,
       );

--- a/src/cli/commands/fill.ts
+++ b/src/cli/commands/fill.ts
@@ -3,6 +3,8 @@ import { actionArgs } from "#cli/args.js";
 import { managedFill } from "#engine/act/element.js";
 import {
   actionTarget,
+  attachSnapDiff,
+  bool,
   type CliArgs,
   positionals,
   print,
@@ -14,7 +16,7 @@ export default defineCommand({
   meta: {
     name: "fill",
     description:
-      "Purpose: fill a single input by ref, selector, or semantic locator.\nExamples:\n  pw fill -s task-a --label Email agent@example.com\n  pw fill -s task-a --selector '#email' agent@example.com\nNotes: use `fill-form` when a whole form should be filled from JSON.",
+      "Purpose: fill a single input by ref, selector, or semantic locator.\nExamples:\n  pw fill -s task-a --label Email agent@example.com\n  pw fill -s task-a --selector '#email' agent@example.com\n  pw fill -s task-a --ref e3 'value' --diff\nNotes: use `fill-form` when a whole form should be filled from JSON. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
@@ -28,6 +30,7 @@ export default defineCommand({
       const value = parts.join(" ");
       const sessionName = session(a);
       const result = await managedFill({ sessionName, ...actionTarget(a, ref), value });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
       print("fill", result, a);
     } catch (error) {
       withCliError("fill", a, error, "fill failed");

--- a/src/cli/commands/fill.ts
+++ b/src/cli/commands/fill.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedFill } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: fill a single input by ref, selector, or semantic locator.\nExamples:\n  pw fill -s task-a --label Email agent@example.com\n  pw fill -s task-a --selector '#email' agent@example.com\n  pw fill -s task-a --ref e3 'value' --diff\nNotes: use `fill-form` when a whole form should be filled from JSON. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/hover.ts
+++ b/src/cli/commands/hover.ts
@@ -1,22 +1,33 @@
 import { defineCommand } from "citty";
 import { actionArgs } from "#cli/args.js";
 import { managedHover } from "#engine/act/element.js";
-import { actionTarget, type CliArgs, firstPos, print, session, withCliError } from "./_helpers.js";
+import {
+  actionTarget,
+  attachSnapDiff,
+  bool,
+  type CliArgs,
+  firstPos,
+  print,
+  session,
+  withCliError,
+} from "./_helpers.js";
 
 export default defineCommand({
   meta: {
     name: "hover",
     description:
-      "Purpose: hover an element by ref, selector, or semantic locator.\nExamples:\n  pw hover -s task-a --text Menu\n  pw hover -s task-a --selector '.menu-trigger'\nNotes: use a read-only command after hover to inspect revealed content.",
+      "Purpose: hover an element by ref, selector, or semantic locator.\nExamples:\n  pw hover -s task-a --text Menu\n  pw hover -s task-a --selector '.menu-trigger'\nNotes: use a read-only command after hover to inspect revealed content. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {
+      const sessionName = session(a);
       const result = await managedHover({
-        sessionName: session(a),
+        sessionName,
         ...actionTarget(a, firstPos(a)),
       });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
       print("hover", result, a);
     } catch (error) {
       withCliError("hover", a, error, "hover failed");

--- a/src/cli/commands/hover.ts
+++ b/src/cli/commands/hover.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedHover } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: hover an element by ref, selector, or semantic locator.\nExamples:\n  pw hover -s task-a --text Menu\n  pw hover -s task-a --selector '.menu-trigger'\nNotes: use a read-only command after hover to inspect revealed content. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/select.ts
+++ b/src/cli/commands/select.ts
@@ -3,6 +3,8 @@ import { actionArgs } from "#cli/args.js";
 import { managedSelect } from "#engine/act/element.js";
 import {
   actionTarget,
+  attachSnapDiff,
+  bool,
   type CliArgs,
   positionals,
   print,
@@ -14,7 +16,7 @@ export default defineCommand({
   meta: {
     name: "select",
     description:
-      "Purpose: select an option in a select control by ref, selector, or semantic locator.\nExamples:\n  pw select -s task-a --label Country US\n  pw select -s task-a --selector '#country' US\nNotes: pass the option value expected by the page.",
+      "Purpose: select an option in a select control by ref, selector, or semantic locator.\nExamples:\n  pw select -s task-a --label Country US\n  pw select -s task-a --selector '#country' US\n  pw select -s task-a --ref e8 'US' --diff\nNotes: pass the option value expected by the page. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
@@ -26,11 +28,10 @@ export default defineCommand({
       );
       const ref = hasFlagTarget ? undefined : parts.shift();
       const value = parts.join(" ");
-      print(
-        "select",
-        await managedSelect({ sessionName: session(a), ...actionTarget(a, ref), value }),
-        a,
-      );
+      const sessionName = session(a);
+      const result = await managedSelect({ sessionName, ...actionTarget(a, ref), value });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
+      print("select", result, a);
     } catch (error) {
       withCliError("select", a, error, "select failed");
     }

--- a/src/cli/commands/select.ts
+++ b/src/cli/commands/select.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedSelect } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: select an option in a select control by ref, selector, or semantic locator.\nExamples:\n  pw select -s task-a --label Country US\n  pw select -s task-a --selector '#country' US\n  pw select -s task-a --ref e8 'US' --diff\nNotes: pass the option value expected by the page. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/type.ts
+++ b/src/cli/commands/type.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedType } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: type text into the focused page or a target element.\nExamples:\n  pw type -s task-a --selector '#search' query\n  pw type -s task-a 'free text'\nNotes: prefer `fill` for replacing input value; use `type` when key events matter. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/type.ts
+++ b/src/cli/commands/type.ts
@@ -3,6 +3,8 @@ import { actionArgs } from "#cli/args.js";
 import { managedType } from "#engine/act/element.js";
 import {
   actionTarget,
+  attachSnapDiff,
+  bool,
   type CliArgs,
   positionals,
   print,
@@ -14,7 +16,7 @@ export default defineCommand({
   meta: {
     name: "type",
     description:
-      "Purpose: type text into the focused page or a target element.\nExamples:\n  pw type -s task-a --selector '#search' query\n  pw type -s task-a 'free text'\nNotes: prefer `fill` for replacing input value; use `type` when key events matter.",
+      "Purpose: type text into the focused page or a target element.\nExamples:\n  pw type -s task-a --selector '#search' query\n  pw type -s task-a 'free text'\nNotes: prefer `fill` for replacing input value; use `type` when key events matter. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
@@ -26,7 +28,9 @@ export default defineCommand({
       );
       const ref = hasFlagTarget || parts.length === 1 ? undefined : parts.shift();
       const value = parts.join(" ");
-      const result = await managedType({ sessionName: session(a), ...actionTarget(a, ref), value });
+      const sessionName = session(a);
+      const result = await managedType({ sessionName, ...actionTarget(a, ref), value });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
       print("type", result, a);
     } catch (error) {
       withCliError("type", a, error, "type failed");

--- a/src/cli/commands/uncheck.ts
+++ b/src/cli/commands/uncheck.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { actionArgs } from "#cli/args.js";
+import { interactiveActionArgs } from "#cli/args.js";
 import { managedUncheck } from "#engine/act/element.js";
 import {
   actionTarget,
@@ -18,7 +18,7 @@ export default defineCommand({
     description:
       "Purpose: uncheck a checkbox control by ref, selector, or semantic locator.\nExamples:\n  pw uncheck -s task-a --label Subscribe\n  pw uncheck -s task-a --selector '#subscribe'\nNotes: use `is checked` afterward when the checked state matters. Use `--diff` to see accessibility tree changes after the action.",
   },
-  args: actionArgs,
+  args: interactiveActionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {

--- a/src/cli/commands/uncheck.ts
+++ b/src/cli/commands/uncheck.ts
@@ -1,23 +1,31 @@
 import { defineCommand } from "citty";
 import { actionArgs } from "#cli/args.js";
 import { managedUncheck } from "#engine/act/element.js";
-import { actionTarget, type CliArgs, firstPos, print, session, withCliError } from "./_helpers.js";
+import {
+  actionTarget,
+  attachSnapDiff,
+  bool,
+  type CliArgs,
+  firstPos,
+  print,
+  session,
+  withCliError,
+} from "./_helpers.js";
 
 export default defineCommand({
   meta: {
     name: "uncheck",
     description:
-      "Purpose: uncheck a checkbox control by ref, selector, or semantic locator.\nExamples:\n  pw uncheck -s task-a --label Subscribe\n  pw uncheck -s task-a --selector '#subscribe'\nNotes: use `is checked` afterward when the checked state matters.",
+      "Purpose: uncheck a checkbox control by ref, selector, or semantic locator.\nExamples:\n  pw uncheck -s task-a --label Subscribe\n  pw uncheck -s task-a --selector '#subscribe'\nNotes: use `is checked` afterward when the checked state matters. Use `--diff` to see accessibility tree changes after the action.",
   },
   args: actionArgs,
   async run({ args }) {
     const a = args as CliArgs;
     try {
-      print(
-        "uncheck",
-        await managedUncheck({ sessionName: session(a), ...actionTarget(a, firstPos(a)) }),
-        a,
-      );
+      const sessionName = session(a);
+      const result = await managedUncheck({ sessionName, ...actionTarget(a, firstPos(a)) });
+      if (bool(a["snap-diff"])) await attachSnapDiff(sessionName, result);
+      print("uncheck", result, a);
     } catch (error) {
       withCliError("uncheck", a, error, "uncheck failed");
     }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -118,7 +118,10 @@ function commandEnvelope(command: string, result: CommandResult) {
       : {}),
     data,
   };
-  if (contentBoundariesEnabled() && pageContentCommand(command)) {
+  if (
+    contentBoundariesEnabled() &&
+    (pageContentCommand(command) || "snapshotDiff" in result.data)
+  ) {
     return {
       ...envelope,
       _boundary: {
@@ -491,6 +494,12 @@ function formatAction(command: string, result: CommandResult): string {
   }
   lines.push(...formatDiagnosticsDelta(result.data.diagnosticsDelta));
   const snapDiff = result.data.snapshotDiff;
+  if (snapDiff && typeof snapDiff === "object" && "diffText" in snapDiff) {
+    lines.push("");
+    lines.push(
+      withTextBoundary("accessibility", result, (snapDiff as { diffText: string }).diffText),
+    );
+  }
   if (snapDiff && typeof snapDiff === "object" && "diffText" in snapDiff) {
     lines.push("");
     lines.push((snapDiff as { diffText: string }).diffText);

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -490,6 +490,11 @@ function formatAction(command: string, result: CommandResult): string {
     lines.push(`Next step: pw tab select ${op.pageId} --session <name>`);
   }
   lines.push(...formatDiagnosticsDelta(result.data.diagnosticsDelta));
+  const snapDiff = result.data.snapshotDiff;
+  if (snapDiff && typeof snapDiff === "object" && "diffText" in snapDiff) {
+    lines.push("");
+    lines.push((snapDiff as { diffText: string }).diffText);
+  }
   return lines.join("\n");
 }
 

--- a/src/engine/environment.ts
+++ b/src/engine/environment.ts
@@ -409,6 +409,7 @@ export async function managedEnvironmentClockResume(options?: ManagedEnvironment
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { ensureRuntimeDir } from "#store/runtime-dir.js";
 
 export type ChromeProfileInfo = {
   browser: "chrome";
@@ -557,6 +558,7 @@ export async function writeChromeProfileConfig(
     },
   };
 
+  await ensureRuntimeDir();
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
   return { configPath, profile };

--- a/src/engine/identity.ts
+++ b/src/engine/identity.ts
@@ -392,6 +392,7 @@ export async function managedAuthProbe(options?: AuthProbeOptions) {
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
+import { ensureRuntimeDir } from "#store/runtime-dir.js";
 
 export type StateDiffOptions = {
   sessionName?: string;
@@ -1319,6 +1320,7 @@ export async function managedStateSave(file?: string, options?: { sessionName?: 
     }`,
   });
   const state = result.data.result;
+  if (!file) await ensureRuntimeDir();
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(state, null, 2), "utf8");
 

--- a/src/engine/observe.ts
+++ b/src/engine/observe.ts
@@ -10,8 +10,15 @@ function extractSnapshotRefs(snapshot: string) {
   return [...snapshot.matchAll(/\[ref=((?:f[0-9]+)?e[0-9]+)\]/g)].map((match) => match[1]);
 }
 
-async function recordSnapshotRefEpoch(options: { sessionName?: string; snapshot: string }) {
+async function recordSnapshotRefEpoch(options: {
+  sessionName?: string;
+  snapshot: string;
+  snapDiffCache?: { yaml: string; interactive: boolean; compact: boolean };
+}) {
   const refs = extractSnapshotRefs(options.snapshot);
+  const cacheJson = options.snapDiffCache
+    ? JSON.stringify({ ...options.snapDiffCache, capturedAt: new Date().toISOString() })
+    : "null";
   const result = await managedRunCode({
     sessionName: options.sessionName,
     source: `async page => {
@@ -34,10 +41,27 @@ async function recordSnapshotRefEpoch(options: { sessionName?: string; snapshot:
         refs: ${JSON.stringify(refs)},
       };
       state.lastSnapshotRefEpoch = epoch;
+      state.lastSnapshotCache = ${cacheJson};
       return JSON.stringify(epoch);
     }`,
   });
   return result.data.result;
+}
+
+export async function loadSnapshotCache(
+  sessionName?: string,
+): Promise<{ yaml: string; interactive: boolean; compact: boolean } | null> {
+  const result = await managedRunCode({
+    sessionName,
+    source: `async page => {
+      ${pageIdRuntimePrelude()}
+      return JSON.stringify(state.lastSnapshotCache || null);
+    }`,
+  });
+  const raw = result.data.result;
+  if (raw && typeof raw === "object" && "yaml" in raw)
+    return raw as { yaml: string; interactive: boolean; compact: boolean };
+  return null;
 }
 
 export async function managedSnapshot(options?: {
@@ -68,6 +92,11 @@ export async function managedSnapshot(options?: {
     await recordSnapshotRefEpoch({
       sessionName: options?.sessionName,
       snapshot: projectedSnapshot,
+      snapDiffCache: {
+        yaml: projectedSnapshot,
+        interactive: Boolean(options?.interactive),
+        compact: Boolean(options?.compact),
+      },
     });
   }
   return {

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from "node:path";
 import { assertActionAllowed } from "#store/action-policy.js";
 import { writeBootstrapConfig } from "#store/config.js";
 import { assertSessionAutomationControl } from "#store/control-state.js";
+import { ensureRuntimeDir } from "#store/runtime-dir.js";
 import { buildAllowedDomainState, isUrlAllowed, normalizeAllowedDomains } from "./domain-guard.js";
 import {
   DIAGNOSTICS_STATE_KEY,
@@ -282,6 +283,7 @@ async function acquireSessionLock(options: {
   const token = randomUUID();
   const startedAt = Date.now();
 
+  await ensureRuntimeDir(options.workspaceDir ?? process.cwd());
   await mkdir(root, { recursive: true });
 
   while (true) {

--- a/src/engine/snapshot-diff.ts
+++ b/src/engine/snapshot-diff.ts
@@ -1,0 +1,112 @@
+import { loadSnapshotCache, managedSnapshot } from "./observe.js";
+
+export interface SnapshotDiffResult {
+  added: string[];
+  changed: string[];
+  removed: string[];
+  diffText: string;
+}
+
+/**
+ * Parse ARIA YAML into ref → content map.
+ * Content includes the ref's own line (without [ref=...]) and child lines
+ * (until the next ref or top-level line).
+ */
+function parseRefNodes(yaml: string): Map<string, string> {
+  const lines = yaml.split("\n");
+  const result = new Map<string, string>();
+  let currentRef: string | null = null;
+  let currentContent: string[] = [];
+  let currentIndent = 0;
+
+  for (const line of lines) {
+    const refMatch = line.match(/\[ref=((?:f[0-9]+)?e[0-9]+)\]/);
+    const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+
+    if (refMatch) {
+      if (currentRef) {
+        result.set(currentRef, currentContent.join("\n"));
+      }
+      currentRef = refMatch[1];
+      currentIndent = indent;
+      currentContent = [line.replace(/\[ref=[^\]]+\]/, "").trim()];
+    } else if (currentRef && indent > currentIndent) {
+      currentContent.push(line.trim());
+    } else {
+      if (currentRef) {
+        result.set(currentRef, currentContent.join("\n"));
+        currentRef = null;
+        currentContent = [];
+      }
+    }
+  }
+
+  if (currentRef) {
+    result.set(currentRef, currentContent.join("\n"));
+  }
+
+  return result;
+}
+
+export function diffSnapshots(beforeYaml: string, afterYaml: string): SnapshotDiffResult {
+  const beforeMap = parseRefNodes(beforeYaml);
+  const afterMap = parseRefNodes(afterYaml);
+
+  const added: string[] = [];
+  const changed: string[] = [];
+  const removed: string[] = [];
+
+  for (const [ref, afterContent] of afterMap) {
+    const beforeContent = beforeMap.get(ref);
+    if (!beforeContent) added.push(ref);
+    else if (beforeContent !== afterContent) changed.push(ref);
+  }
+  for (const ref of beforeMap.keys()) {
+    if (!afterMap.has(ref)) removed.push(ref);
+  }
+
+  const addedSet = new Set(added);
+  const changedSet = new Set(changed);
+  const diffLines: string[] = [];
+  diffLines.push(`# snap-diff: +${added.length} ~${changed.length} -${removed.length}`);
+
+  for (const line of afterYaml.split("\n")) {
+    const refMatch = line.match(/\[ref=((?:f[0-9]+)?e[0-9]+)\]/);
+    if (refMatch) {
+      const ref = refMatch[1];
+      if (addedSet.has(ref)) diffLines.push(line + " [+]");
+      else if (changedSet.has(ref)) diffLines.push(line + " [~]");
+      else diffLines.push(line);
+    } else {
+      diffLines.push(line);
+    }
+  }
+
+  if (removed.length > 0) {
+    diffLines.push(`# removed: ${removed.join(", ")}`);
+  }
+
+  return { added, changed, removed, diffText: diffLines.join("\n").trim() };
+}
+
+/**
+ * Load cached snapshot, take a fresh snapshot, and diff.
+ * Called after an action completes when --snap-diff is set.
+ */
+export async function computePostActionDiff(
+  sessionName?: string,
+): Promise<SnapshotDiffResult | null> {
+  const cache = await loadSnapshotCache(sessionName);
+  if (!cache?.yaml) return null;
+
+  const after = await managedSnapshot({
+    sessionName,
+    interactive: cache.interactive,
+    compact: cache.compact,
+  });
+
+  const afterYaml = typeof after.data.snapshot === "string" ? after.data.snapshot : "";
+  if (!afterYaml) return null;
+
+  return diffSnapshots(cache.yaml, afterYaml);
+}

--- a/src/store/artifacts.ts
+++ b/src/store/artifacts.ts
@@ -1,7 +1,9 @@
 import { appendFile, mkdir, readdir, readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 export async function ensureRunDir(sessionName?: string) {
+  await ensureRuntimeDir();
   const base = resolve(".pwcli", "runs");
   const runId = `${new Date().toISOString().replace(/[:.]/g, "-")}-${sessionName ?? "no-session"}`;
   const runDir = join(base, runId);

--- a/src/store/auth-profile.ts
+++ b/src/store/auth-profile.ts
@@ -1,6 +1,7 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 type StoredProfile = {
   url: string;
@@ -50,6 +51,7 @@ function decryptJson(text: string): StoredProfile {
 }
 
 export async function saveAuthProfile(name: string, profile: StoredProfile) {
+  await ensureRuntimeDir();
   await mkdir(authProfileDir(), { recursive: true });
   const path = authProfilePath(name);
   await writeFile(path, JSON.stringify(encryptJson(profile), null, 2), "utf8");
@@ -63,6 +65,7 @@ export async function loadAuthProfile(name: string) {
 }
 
 export async function listAuthProfiles() {
+  await ensureRuntimeDir();
   await mkdir(authProfileDir(), { recursive: true });
   const entries = await readdir(authProfileDir(), { withFileTypes: true });
   const profiles = [];

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -1,6 +1,7 @@
 import { constants } from "node:fs";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 // ─── Playwright daemon session config ────────────────────────────────────────
 
@@ -85,6 +86,7 @@ export async function writeSessionRuntimeConfig(options: {
     overrides as JsonObject,
   ) as SessionRuntimeConfig;
   const configPath = sessionRuntimeConfigPath(options.sessionName);
+  await ensureRuntimeDir();
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
   return { configPath, config };
@@ -116,6 +118,7 @@ export async function writeBootstrapConfig(
   config: BootstrapConfig,
 ): Promise<void> {
   const configPath = bootstrapConfigPath(sessionName);
+  await ensureRuntimeDir();
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
 }

--- a/src/store/control-state.ts
+++ b/src/store/control-state.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 export type ControlStateRecord = {
   sessionName: string;
@@ -18,6 +19,7 @@ function controlStatePath(sessionName: string) {
 }
 
 export async function writeControlState(record: ControlStateRecord) {
+  await ensureRuntimeDir();
   await mkdir(controlStateDir(), { recursive: true });
   await writeFile(controlStatePath(record.sessionName), JSON.stringify(record, null, 2), "utf8");
 }

--- a/src/store/profile-state.ts
+++ b/src/store/profile-state.ts
@@ -1,5 +1,6 @@
 import { mkdir, readdir, rm, stat } from "node:fs/promises";
 import { resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 function profileStateDir() {
   return resolve(".pwcli", "profiles", "state");
@@ -14,6 +15,7 @@ export function resolveProfileStatePath(name: string) {
 }
 
 export async function ensureProfileStateDir() {
+  await ensureRuntimeDir();
   await mkdir(profileStateDir(), { recursive: true });
 }
 

--- a/src/store/runtime-dir.ts
+++ b/src/store/runtime-dir.ts
@@ -1,0 +1,17 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export function runtimeDir(baseDir: string = process.cwd(), ...segments: string[]): string {
+  return resolve(baseDir, ".pwcli", ...segments);
+}
+
+export async function ensureRuntimeDir(baseDir: string = process.cwd()): Promise<void> {
+  const dir = resolve(baseDir, ".pwcli");
+  await mkdir(dir, { recursive: true });
+  const gitignorePath = resolve(dir, ".gitignore");
+  try {
+    await access(gitignorePath);
+  } catch {
+    await writeFile(gitignorePath, "*\n", "utf8");
+  }
+}

--- a/src/store/stream.ts
+++ b/src/store/stream.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { ensureRuntimeDir } from "./runtime-dir.js";
 
 export type StreamSessionRecord = {
   sessionName: string;
@@ -18,6 +19,7 @@ function streamPath(sessionName: string) {
 }
 
 export async function writeStreamRecord(record: StreamSessionRecord) {
+  await ensureRuntimeDir();
   await mkdir(streamDir(), { recursive: true });
   await writeFile(streamPath(record.sessionName), JSON.stringify(record, null, 2), "utf8");
 }

--- a/test/unit/snapshot-diff.test.ts
+++ b/test/unit/snapshot-diff.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { diffSnapshots } from "../../src/engine/snapshot-diff.js";
+
+describe("diffSnapshots", () => {
+  it("detects added refs", () => {
+    const before = '- link "Home" [ref=e0]';
+    const after = '- link "Home" [ref=e0]\n- button "New" [ref=e1]';
+    const result = diffSnapshots(before, after);
+    assert.deepEqual(result.added, ["e1"]);
+    assert.deepEqual(result.changed, []);
+    assert.deepEqual(result.removed, []);
+    assert.ok(result.diffText.includes("[+]"));
+  });
+
+  it("detects changed refs via child content", () => {
+    const before = '- textbox [ref=e0]:\n  - text: "old"';
+    const after = '- textbox [ref=e0]:\n  - text: "new"';
+    const result = diffSnapshots(before, after);
+    assert.deepEqual(result.added, []);
+    assert.ok(result.changed.includes("e0"));
+    assert.deepEqual(result.removed, []);
+    assert.ok(result.diffText.includes("[~]"));
+  });
+
+  it("detects removed refs", () => {
+    const before = '- link "Home" [ref=e0]\n- button "Delete" [ref=e1]';
+    const after = '- link "Home" [ref=e0]';
+    const result = diffSnapshots(before, after);
+    assert.deepEqual(result.added, []);
+    assert.deepEqual(result.changed, []);
+    assert.deepEqual(result.removed, ["e1"]);
+    assert.ok(result.diffText.includes("# removed: e1"));
+  });
+
+  it("returns empty diff for identical snapshots", () => {
+    const yaml = '- link "Home" [ref=e0]\n- button "Submit" [ref=e1]';
+    const result = diffSnapshots(yaml, yaml);
+    assert.deepEqual(result.added, []);
+    assert.deepEqual(result.changed, []);
+    assert.deepEqual(result.removed, []);
+    assert.ok(result.diffText.includes("+0 ~0 -0"));
+  });
+
+  it("handles multiple changes at once", () => {
+    const before = [
+      '- link "Home" [ref=e0]',
+      "- textbox [ref=e1]:",
+      '  - text: "old"',
+      '- button "Delete" [ref=e2]',
+    ].join("\n");
+    const after = [
+      '- link "Home" [ref=e0]',
+      "- textbox [ref=e1]:",
+      '  - text: "new"',
+      '- button "Save" [ref=e3]',
+    ].join("\n");
+    const result = diffSnapshots(before, after);
+    assert.deepEqual(result.added, ["e3"]);
+    assert.deepEqual(result.changed, ["e1"]);
+    assert.deepEqual(result.removed, ["e2"]);
+  });
+
+  it("handles iframe refs", () => {
+    const before = '- button "Old" [ref=f1e0]';
+    const after = '- button "New" [ref=f1e0]';
+    const result = diffSnapshots(before, after);
+    assert.deepEqual(result.changed, ["f1e0"]);
+  });
+});

--- a/test/unit/snapshot-diff.test.ts
+++ b/test/unit/snapshot-diff.test.ts
@@ -1,5 +1,5 @@
-import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import { diffSnapshots } from "../../src/engine/snapshot-diff.js";
 
 describe("diffSnapshots", () => {


### PR DESCRIPTION
## 背景

参考 PinchTab 的 `--snap-diff` 机制，在 action 命令执行后自动对比前后无障碍树快照，返回带增量标记的 diff。

## 改动

| 文件 | 操作 | 内容 |
|---|---|---|
| `src/engine/snapshot-diff.ts` | 新增 | diff 引擎：`parseRefNodes`、`diffSnapshots`、`computePostActionDiff` |
| `src/engine/observe.ts` | 改 | `managedSnapshot` 缓存 projected YAML 到 browser-side state + 新增 `loadSnapshotCache` |
| `src/cli/args.ts` | 改 | `actionArgs` 新增 `--snap-diff`（alias `--diff`） |
| `src/cli/commands/_helpers.ts` | 改 | 新增 `attachSnapDiff` helper |
| `src/cli/commands/click.ts` 等 7 个 | 改 | 透传 `--snap-diff` flag + 更新 help |
| `src/cli/output.ts` | 改 | `formatAction` 输出 diff |
| `skills/pwcli/SKILL.md` | 改 | 新增「增量快照 diff」文档段落 |
| `test/unit/snapshot-diff.test.ts` | 新增 | 6 个单测 |

## 用法

```bash
pw snapshot -i -s task-a          # 建立基线
pw click e5 -s task-a --diff      # action 后返回增量 diff
pw fill e3 "hello" -s task-a --diff
```

## 设计决策

- **Best-effort**：diff 失败不影响 action 本身的成败
- **缓存在 browser-side state**：和 `lastSnapshotRefEpoch` 共用同一轮 `managedRunCode` 调用，无额外 round-trip
- **ref 做 join key**：Playwright 的 ref 缓存在 DOM 元素上（`element._ariaRef`），同物理元素跨 snapshot 保持稳定
- **不做文件持久化**：session 关闭即丢，和 ref epoch 生命周期一致

## 测试

```
pnpm test:unit  →  9 pass / 0 fail
pnpm build      →  clean
```