### PR TITLE
fix: remove text/observe aliases and converge diagnostics grep

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Auto-run format check on staged files before commit
+set -e
+
+STAGED_TS_JS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|js|mjs|cjs|json|md)$' || true)
+
+if [ -n "$STAGED_TS_JS" ]; then
+  echo "[pre-commit] Running biome check on staged files..."
+  echo "$STAGED_TS_JS" | xargs npx biome check --diagnostic-level=error
+fi
+
+echo "[pre-commit] OK"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ node dist/cli.js --help
 
 ```bash
 pw session create bug-a --headed --open 'https://example.com'
-pw observe status -s bug-a
+pw status -s bug-a
 pw read-text -s bug-a --max-chars 2000
 pw snapshot -i -s bug-a
 pw find-best -s bug-a submit_form

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "tsx src/cli.ts",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json",
-    "prepare": "npm run build",
+    "prepare": "node -e \"try{require('child_process').execSync('git config core.hooksPath .githooks',{stdio:'ignore'})}catch{}\" && npm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "biome check --diagnostic-level=error .",
     "lint:fix": "biome check --write .",

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -38,8 +38,8 @@ pw skill show --full
 |---|---|---|
 | 会话生命周期 | `session` | `pw session --help` |
 | 导航 | `open` | `pw open --help` |
-| 页面概览 | `status` / `observe` / `page` / `tab` | `pw status --help` |
-| 文本和结构读取 | `read-text` / `text` / `snapshot` / `accessibility` | `pw read-text --help` |
+| 页面概览 | `status` / `page` / `tab` | `pw status --help` |
+| 文本和结构读取 | `read-text` / `snapshot` / `accessibility` | `pw read-text --help` |
 | 定位和状态检查 | `locate` / `get` / `is` / `verify` | `pw locate --help` |
 | semantic intent | `find-best` / `act` | `pw find-best --help` |
 | 点击和输入 | `click` / `fill` / `type` / `press` | `pw click --help` |

--- a/src/cli/batch/executor.ts
+++ b/src/cli/batch/executor.ts
@@ -244,8 +244,7 @@ export async function executeBatchStep(tokens: string[], sessionName: string) {
         data: await managedScreenshot({ sessionName, ref, selector, path, fullPage }),
       };
     }
-    case "read-text":
-    case "text": {
+    case "read-text": {
       let selector: string | undefined;
       let includeOverlay = true;
       let maxChars: number | undefined;
@@ -284,10 +283,7 @@ export async function executeBatchStep(tokens: string[], sessionName: string) {
           data: await managedPageDialogs({ sessionName }),
         };
       throw new Error(`unsupported page batch step '${rawStep}'`);
-    case "observe":
     case "status":
-      if (command === "observe" && args[0] !== "status")
-        throw new Error(`unsupported observe batch step '${rawStep}'`);
       return { ok: true, command: "status", data: await managedObserveStatus({ sessionName }) };
     case "errors":
       if (args[0] !== "recent" && args[0] !== "clear")

--- a/src/cli/batch/plan.ts
+++ b/src/cli/batch/plan.ts
@@ -9,7 +9,6 @@ export const SUPPORTED_BATCH_TOP_LEVEL = [
   "hover",
   "is",
   "locate",
-  "observe",
   "open",
   "page",
   "press",

--- a/src/cli/commands/diagnostics.ts
+++ b/src/cli/commands/diagnostics.ts
@@ -109,7 +109,7 @@ const runs = defineCommand({
   meta: {
     name: "runs",
     description:
-      "Purpose: list recorded command/action runs.\nExamples:\n  pw diagnostics runs -s task-a --limit 20\n  pw diagnostics runs --since 2026-01-01T00:00:00.000Z\nNotes: use run ids with `diagnostics show`, `grep`, or `digest --run`.",
+      "Purpose: list recorded command/action runs.\nExamples:\n  pw diagnostics runs -s task-a --limit 20\n  pw diagnostics runs --since 2026-01-01T00:00:00.000Z\nNotes: use run ids with `diagnostics show` or `digest --run`."
   },
   args: {
     ...sharedArgs,
@@ -212,14 +212,6 @@ const show = defineCommand({
     }
   },
 });
-const grep = defineCommand({
-  ...show,
-  meta: {
-    name: "grep",
-    description:
-      "Purpose: search recorded run events by command or text.\nExamples:\n  pw diagnostics grep --run <runId> --text TypeError\n  pw diagnostics grep --run <runId> --command click\nNotes: use grep to find a specific signal inside a larger recorded run.",
-  },
-});
 const timeline = defineCommand({
   meta: {
     name: "timeline",
@@ -258,5 +250,5 @@ const timeline = defineCommand({
 
 export default defineCommand({
   meta: { name: "diagnostics", description: "Diagnostics export, runs, digest and bundle" },
-  subCommands: { export: exportCmd, bundle, runs, digest, show, grep, timeline },
+  subCommands: { export: exportCmd, bundle, runs, digest, show, timeline },
 });

--- a/src/cli/commands/diagnostics.ts
+++ b/src/cli/commands/diagnostics.ts
@@ -109,7 +109,7 @@ const runs = defineCommand({
   meta: {
     name: "runs",
     description:
-      "Purpose: list recorded command/action runs.\nExamples:\n  pw diagnostics runs -s task-a --limit 20\n  pw diagnostics runs --since 2026-01-01T00:00:00.000Z\nNotes: use run ids with `diagnostics show` or `digest --run`."
+      "Purpose: list recorded command/action runs.\nExamples:\n  pw diagnostics runs -s task-a --limit 20\n  pw diagnostics runs --since 2026-01-01T00:00:00.000Z\nNotes: use run ids with `diagnostics show` or `digest --run`.",
   },
   args: {
     ...sharedArgs,

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -4,9 +4,7 @@ const _lazy = (path: string) => () =>
 export default {
   snapshot: () => import("./snapshot.js").then((m) => m.default),
   "read-text": () => import("./read-text.js").then((m) => m.default),
-  text: () => import("./read-text.js").then((m) => m.default),
   status: () => import("./status.js").then((m) => m.default),
-  observe: () => import("./status.js").then((m) => m.default),
   screenshot: () => import("./screenshot.js").then((m) => m.default),
   pdf: () => import("./pdf.js").then((m) => m.default),
   accessibility: () => import("./accessibility.js").then((m) => m.default),

--- a/src/engine/act/element.ts
+++ b/src/engine/act/element.ts
@@ -209,7 +209,7 @@ export function reSnapshotRecovery(sessionName: string | undefined): ActionFailu
 export function inspectRecovery(sessionName: string | undefined): ActionFailureRecovery {
   return makeRecovery("inspect", [
     `pw snapshot -i ${sessionFlag(sessionName)}`,
-    `pw observe status ${sessionFlag(sessionName)}`,
+    `pw status ${sessionFlag(sessionName)}`,
   ]);
 }
 
@@ -217,7 +217,7 @@ export function inspectWithStatusFirstRecovery(
   sessionName: string | undefined,
 ): ActionFailureRecovery {
   return makeRecovery("inspect", [
-    `pw observe status ${sessionFlag(sessionName)}`,
+    `pw status ${sessionFlag(sessionName)}`,
     `pw snapshot -i ${sessionFlag(sessionName)}`,
   ]);
 }
@@ -301,7 +301,7 @@ export function actionTimeoutOrNotActionableFailure(
     retryable: true,
     suggestions: [
       "Wait for the target with a selector before retrying the action",
-      `Check page readiness with \`pw observe status ${sessionFlag(context.sessionName)}\``,
+      `Check page readiness with \`pw status ${sessionFlag(context.sessionName)}\``,
       "Clear any dialog, modal, or overlay that may block the target",
     ],
     recovery: inspectWithStatusFirstRecovery(context.sessionName),

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -1472,7 +1472,7 @@ export function sessionRoutingError(message: string) {
       ],
       recovery: {
         kind: "retry" as const,
-        commands: ["pw session status <name>", "pw observe status --session <name>"],
+        commands: ["pw session status <name>", "pw status --session <name>"],
       },
       details: { session: name, timeoutMs: Number(timeoutMs) },
     };

--- a/test/contract/evaluate-product-surface.js
+++ b/test/contract/evaluate-product-surface.js
@@ -22,15 +22,7 @@ const surfaces = {
   },
   B: {
     title: "Page Reading and Workspace Facts",
-    commands: [
-      "read-text",
-      "snapshot",
-      "accessibility",
-      "page",
-      "tab",
-      "screenshot",
-      "pdf",
-    ],
+    commands: ["read-text", "snapshot", "accessibility", "page", "tab", "screenshot", "pdf"],
     checks: [
       ["tsx", "--test", "test/integration/page-reading.test.ts"],
       ["tsx", "--test", "test/integration/accessibility.test.ts"],

--- a/test/contract/evaluate-product-surface.js
+++ b/test/contract/evaluate-product-surface.js
@@ -18,14 +18,12 @@ const surfaces = {
       ["node", "dist/cli.js", "session", "--help"],
       ["node", "dist/cli.js", "open", "--help"],
       ["node", "dist/cli.js", "status", "--help"],
-      ["node", "dist/cli.js", "observe", "--help"],
     ],
   },
   B: {
     title: "Page Reading and Workspace Facts",
     commands: [
       "read-text",
-      "text",
       "snapshot",
       "accessibility",
       "page",

--- a/test/e2e/pwcli-dogfood-e2e.sh
+++ b/test/e2e/pwcli-dogfood-e2e.sh
@@ -123,7 +123,7 @@ printf 'upload-check\n' >"$UPLOAD_FILE"
 mkdir -p "$DOWNLOAD_DIR"
 cat >"$BATCH_FILE" <<'JSON'
 [
-  ["observe", "status"],
+  ["status"],
   ["page", "dialogs"],
   ["route", "list"]
 ]

--- a/test/integration/fixture-app.test.ts
+++ b/test/integration/fixture-app.test.ts
@@ -99,7 +99,6 @@ describe("SUPPORTED_BATCH_TOP_LEVEL", () => {
       "hover",
       "is",
       "locate",
-      "observe",
       "open",
       "page",
       "press",

--- a/test/integration/page-reading.test.ts
+++ b/test/integration/page-reading.test.ts
@@ -18,7 +18,7 @@ describe("page reading", { concurrency: false }, () => {
     }
   });
 
-  it("observe status returns current page url", async () => {
+  it("status returns current page url", async () => {
     const name = makeSessionName();
     sessionsToClean.push(name);
 
@@ -33,8 +33,8 @@ describe("page reading", { concurrency: false }, () => {
       "json",
     ]);
 
-    const result = await runPw(["observe", "status", "--session", name, "--output", "json"]);
-    assert.equal(result.code, 0, `observe failed: ${result.stderr}`);
+    const result = await runPw(["status", "--session", name, "--output", "json"]);
+    assert.equal(result.code, 0, `status failed: ${result.stderr}`);
     const json = result.json as {
       ok: boolean;
       page: { url: string; title: string };
@@ -99,8 +99,8 @@ describe("page reading", { concurrency: false }, () => {
       "json",
     ]);
 
-    const result = await runPw(["text", "--session", name, "--output", "json"]);
-    assert.equal(result.code, 0, `text alias failed: ${result.stderr}`);
+    const result = await runPw(["read-text", "--session", name, "--output", "json"]);
+    assert.equal(result.code, 0, `read-text failed: ${result.stderr}`);
     const json = result.json as {
       ok: boolean;
       command: string;

--- a/test/integration/stream-preview.test.ts
+++ b/test/integration/stream-preview.test.ts
@@ -43,10 +43,10 @@ try {
   assert.equal(statusPayload.ok, true);
   assert.equal(statusPayload.data.healthy, true);
 
-  const observe = await runPw(["observe", "status", "--session", sessionName, "--output", "json"], {
+  const observe = await runPw(["status", "--session", sessionName, "--output", "json"], {
     cwd: workspaceDir,
   });
-  assert.equal(observe.code, 0, `observe status failed: ${observe.stderr}`);
+  assert.equal(observe.code, 0, `status failed: ${observe.stderr}`);
   const observePayload = observe.json as {
     ok: boolean;
     data: { stream?: { supported?: boolean; active?: boolean; healthy?: boolean; url?: string } };

--- a/test/smoke/pwcli-smoke.sh
+++ b/test/smoke/pwcli-smoke.sh
@@ -539,7 +539,7 @@ assert_json "$observe_json" "observe status workspace is healthy" \
 
 log "batch surfaces"
 batch_out="${TMP_DIR}/batch.json"
-if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --output json >"$batch_out"; then
+if ! printf '[["status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --output json >"$batch_out"; then
   log "command failed: ${CLI[*]} batch --session ${SESSION_NAME} --stdin-json"
   cat "$batch_out" >&2 || true
   exit 1
@@ -582,7 +582,7 @@ assert_json "$batch_continue_json" "batch continue-on-error preserves success en
   "data.ok === true && data.data.summary.stepCount === 2 && data.data.summary.successCount === 1 && data.data.summary.failedCount === 1 && data.data.results.length === 2 && data.data.results[0].ok === false && data.data.results[0].error.message.includes('batch continue smoke failure') && data.data.results[1].ok === true"
 
 batch_verbose_out="${TMP_DIR}/batch-verbose.json"
-if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --include-results --output json >"$batch_verbose_out"; then
+if ! printf '[["status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --include-results --output json >"$batch_verbose_out"; then
   log "command failed: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json --include-results"
   cat "$batch_verbose_out" >&2 || true
   exit 1
@@ -592,7 +592,7 @@ assert_json "$batch_verbose_json" "batch include-results keeps full step outputs
   "data.ok === true && Array.isArray(data.data.results) && data.data.results.length === 2 && data.data.results.every(item => item.ok === true)"
 
 batch_summary_only_out="${TMP_DIR}/batch-summary-only.json"
-if ! printf '[["observe","status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --summary-only --output json >"$batch_summary_only_out"; then
+if ! printf '[["status"],["page","dialogs"]]' | "${CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --summary-only --output json >"$batch_summary_only_out"; then
   log "command failed: ${CLI[*]} --output json batch --session ${SESSION_NAME} --stdin-json --summary-only"
   cat "$batch_summary_only_out" >&2 || true
   exit 1
@@ -602,7 +602,7 @@ assert_json "$batch_summary_only_json" "batch summary-only omits full step outpu
   "data.ok === true && data.data.completed === true && data.data.summary.stepCount === 2 && data.data.results === undefined"
 
 batch_text_out="${TMP_DIR}/batch-text.txt"
-printf '[["observe","status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$batch_text_out"
+printf '[["status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json >"$batch_text_out"
 if ! grep -q 'batch completed=true steps=2 success=2 failed=0' "$batch_text_out"; then
   log "batch text summary missing"
   cat "$batch_text_out" >&2
@@ -636,7 +636,7 @@ if ! grep -q 'batch does not support session lifecycle' "$batch_text_fail_out"; 
 fi
 
 batch_text_verbose_out="${TMP_DIR}/batch-text-verbose.txt"
-printf '[["observe","status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --include-results >"$batch_text_verbose_out"
+printf '[["status"],["page","dialogs"]]' | "${TEXT_CLI[@]}" batch --session "$SESSION_NAME" --stdin-json --include-results >"$batch_text_verbose_out"
 if ! grep -q 'steps:' "$batch_text_verbose_out"; then
   log "batch include-results text should show compact steps"
   cat "$batch_text_verbose_out" >&2


### PR DESCRIPTION
## Summary

This PR addresses three reported issues by converging CLI aliases and removing redundant commands:

- **#150** — batch allowlist inconsistently rejected \`text\` (alias for \`read-text\`)
- **#151** — \`diagnostics grep\` was identical to \`diagnostics show\`
- **#152** — RFC to remove \`text\` and \`observe\` aliases entirely

## Changes

### Alias removal
- **CLI registry** (\`src/cli/commands/index.ts\`): removed \`text\` and \`observe\` entries
- **Batch executor** (\`src/cli/batch/executor.ts\`): removed \`case "text":\` and \`case "observe":\` (including fake subcommand check)
- **Batch allowlist** (\`src/cli/batch/plan.ts\`): removed \`"observe"\` from \`SUPPORTED_BATCH_TOP_LEVEL\`

### Diagnostics convergence
- **Diagnostics** (\`src/cli/commands/diagnostics.ts\`): removed \`grep\` subcommand; updated \`runs\` description to reference \`show\` instead of \`grep\`

### Docs & engine strings
- \`README.md\`: \`pw observe status\` → \`pw status\`
- \`skills/pwcli/SKILL.md\`: updated command routing table
- \`src/engine/act/element.ts\`: recovery suggestions use \`pw status\`
- \`src/engine/session.ts\`: routing error commands use \`pw status\`

### Pre-commit hook
- Added \`.githooks/pre-commit\` that runs \`biome check\` on staged \`.ts/.js/.json/.md\` files
- Updated \`package.json\` \`prepare\` script to auto-configure \`core.hooksPath\` on install

### Tests
- Updated all test fixtures, smoke tests, e2e tests, integration tests, and contract tests to use canonical command names

## Verification

- \`pnpm check\` ✅ (typecheck + lint + build + test:unit + integration:core + contract:core)
- Surface A (session lifecycle) ✅
- Surface B (page reading) ✅
- Batch allowlist contract ✅
- Help contract ✅
- Batch verify contract ✅

## Breaking change

\`pw text\`, \`pw observe\`, and \`pw diagnostics grep\` are no longer valid commands. Use \`pw read-text\`, \`pw status\`, and \`pw diagnostics show\` respectively.

Closes #150, closes #151, closes #152