### PR TITLE
Support Electron CDP attach and code probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ pnpm check
 - `page dialogs` 是事件投影，不是 authoritative live dialog set。
 - `MODAL_STATE_BLOCKED` 会阻断需要页面执行上下文的读取和部分动作。
 - `observe status` 和 `doctor` 默认 compact，`--verbose` 才展开完整细节。
-- `session attach --browser-url/--cdp` 只能接管本机可连接的调试端口。
+- `session attach --browser-url/--cdp` 接管本机可连接的 Chromium CDP 调试端口，`--cdp` 也接受 CDP websocket；positional `http://...` 和 `/devtools/` websocket 会自动按 CDP 连接；`--ws-endpoint` 接 Playwright browser server endpoint。

--- a/skills/pwcli/SKILL.md
+++ b/skills/pwcli/SKILL.md
@@ -77,6 +77,34 @@ pw snapshot -i -s explore-a
 
 目标：知道当前 URL、标题、主要文本、关键可交互元素和下一步定位方式。
 
+### 连接已有浏览器 / Electron
+
+已有目标时优先按 endpoint 类型 attach：
+
+```bash
+# Chromium CDP port（Electron/Chrome remote debugging）
+pw session attach electron-a --cdp 9333
+pw session attach electron-a --browser-url http://127.0.0.1:9333
+pw session attach electron-a http://127.0.0.1:9333
+
+# Chromium CDP WebSocket（/json/version 里的 webSocketDebuggerUrl）
+pw session attach electron-a --cdp 'ws://127.0.0.1:9333/devtools/browser/<id>'
+pw session attach electron-a 'ws://127.0.0.1:9333/devtools/browser/<id>'
+
+# Playwright browser server websocket
+pw session attach remote-a --ws-endpoint 'ws://127.0.0.1:3000/<playwright-id>'
+
+# Playwright bound browser registry
+pw session list --attachable
+pw session attach remote-a --attachable-id '<id>'
+
+pw status -s electron-a
+pw snapshot -i -s electron-a
+pw console -s electron-a --level error --limit 20
+```
+
+规则：`http://...` 和 `/devtools/` websocket 自动按 Chromium CDP 连接；非 `/devtools/` websocket 按 Playwright endpoint 连接。桌面端优先走 CDP，不走浏览器 extension。
+
 ### 执行动作
 
 ```bash

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -434,14 +434,18 @@ async function resolveAttachableServer(attachableId: string) {
 		throw new Error(
 			`attachable server '${attachableId}' not found or not connectable`,
 		);
-	return { endpoint: server.endpoint, resolvedVia: "attachable-id" as const };
+	return {
+		endpoint: server.endpoint,
+		resolvedVia: "attachable-id" as const,
+		connectVia: "endpoint" as const,
+	};
 }
 
 const attach = defineCommand({
 	meta: {
 		name: "attach",
 		description:
-			"Purpose: attach a named session to an existing browser endpoint.\nExamples:\n  pw session attach task-a --browser-url http://127.0.0.1:9222\n  pw session attach task-a --attachable-id <id>\nNotes: attach only works with reachable local debugging endpoints or attachable ids.",
+			"Purpose: attach a named session to an existing browser endpoint.\nExamples:\n  pw session attach task-a --cdp 9222\n  pw session attach task-a http://127.0.0.1:9222\n  pw session attach task-a --ws-endpoint ws://127.0.0.1:3000/playwright\n  pw session attach task-a --attachable-id <id>\nNotes: --cdp/--browser-url/http positional endpoints use Chromium CDP; --ws-endpoint uses a Playwright browser server endpoint.",
 	},
 	args: {
 		output: sharedArgs.output,
@@ -452,10 +456,14 @@ const attach = defineCommand({
 		},
 		"browser-url": {
 			type: "string",
-			description: "CDP browser URL",
+			description: "CDP browser HTTP URL",
 			valueHint: "url",
 		},
-		cdp: { type: "string", description: "CDP port", valueHint: "port" },
+		cdp: {
+			type: "string",
+			description: "CDP port, browser URL, or websocket URL",
+			valueHint: "port-or-url",
+		},
 		"attachable-id": {
 			type: "string",
 			description: "Attachable server id",
@@ -488,7 +496,13 @@ const attach = defineCommand({
 				sessionName: name,
 				endpoint: target.endpoint,
 				resolvedVia: target.resolvedVia,
-				...("browserURL" in target ? { browserURL: target.browserURL } : {}),
+				connectVia: target.connectVia,
+				...("browserURL" in target && target.browserURL
+					? { browserURL: target.browserURL }
+					: {}),
+				...("cdpEndpoint" in target && target.cdpEndpoint
+					? { cdpEndpoint: target.cdpEndpoint }
+					: {}),
 			});
 			const appliedDefaults = await applySessionDefaults({
 				sessionName: name,

--- a/src/cli/parsers/session.ts
+++ b/src/cli/parsers/session.ts
@@ -303,8 +303,9 @@ function normalizeURL(value: string) {
 function normalizeCdpEndpoint(value: string) {
 	const trimmed = value.trim();
 	if (/^\d+$/.test(trimmed)) return `http://127.0.0.1:${trimmed}`;
-	if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) return normalizeURL(trimmed);
-	if (/^[^/\s]+:\d+$/.test(trimmed)) return normalizeURL(`http://${trimmed}`);
+	if (/^[^/:\s]+:\d+$/.test(trimmed)) return normalizeURL(`http://${trimmed}`);
+	if (/^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed))
+		return normalizeURL(trimmed);
 	return normalizeURL(trimmed);
 }
 

--- a/src/cli/parsers/session.ts
+++ b/src/cli/parsers/session.ts
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type ActionFailure, isActionFailure } from "#engine/act/element.js";
 import {
@@ -279,127 +277,60 @@ type RawAttachTarget =
 	| { endpoint: string; resolvedVia: "cdp" }
 	| { endpoint: string; resolvedVia: "argument" };
 
-type ResolvedAttachTarget =
-	| {
-			endpoint: string;
-			resolvedVia: "ws-endpoint" | "argument" | "attachable-id";
-	  }
-	| {
-			endpoint: string;
-			resolvedVia: "browser-url" | "cdp";
-			browserURL: string;
-	  };
-
-type AttachBridgeRegistry = {
-	targets?: Array<{
-		browserURL?: string;
-		cdpPort?: number;
-		wsEndpoint?: string;
-		cdpWebSocketDebuggerUrl?: string;
-	}>;
+type ResolvedAttachTarget = {
+	endpoint: string;
+	resolvedVia:
+		| "ws-endpoint"
+		| "browser-url"
+		| "cdp"
+		| "argument"
+		| "attachable-id";
+	connectVia: "endpoint" | "cdp";
+	browserURL?: string;
+	cdpEndpoint?: string;
 };
 
-const ATTACH_BRIDGE_REGISTRY_PATH = join(
-	tmpdir(),
-	"pwcli-attach-target-registry.json",
-);
-
-function normalizeBrowserURL(browserURL: string) {
+function normalizeURL(value: string) {
 	try {
-		const url = new URL(browserURL);
+		const url = new URL(value);
 		if (url.hostname === "localhost") url.hostname = "127.0.0.1";
 		return url.toString().replace(/\/$/, "");
 	} catch {
-		return browserURL.replace(/\/$/, "");
+		return value.replace(/\/$/, "");
 	}
 }
 
-function parseBrowserPort(browserURL: string) {
-	try {
-		const url = new URL(browserURL);
-		return url.port ? Number(url.port) : undefined;
-	} catch {
-		return undefined;
-	}
+function normalizeCdpEndpoint(value: string) {
+	const trimmed = value.trim();
+	if (/^\d+$/.test(trimmed)) return `http://127.0.0.1:${trimmed}`;
+	if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) return normalizeURL(trimmed);
+	if (/^[^/\s]+:\d+$/.test(trimmed)) return normalizeURL(`http://${trimmed}`);
+	return normalizeURL(trimmed);
 }
 
-function normalizeAttachMetadataEndpoint(endpoint: string) {
+function classifyArgumentEndpoint(endpoint: string): "cdp" | "endpoint" {
 	try {
 		const url = new URL(endpoint);
-		if (url.hostname === "localhost") url.hostname = "127.0.0.1";
-		return url.toString();
+		if (url.protocol === "http:" || url.protocol === "https:") return "cdp";
+		if (
+			(url.protocol === "ws:" || url.protocol === "wss:") &&
+			url.pathname.includes("/devtools/")
+		) {
+			return "cdp";
+		}
 	} catch {
-		return endpoint;
+		/* Non-URL arguments are treated as Playwright endpoints. */
 	}
-}
-
-async function readAttachBridgeRegistry() {
-	try {
-		const text = await readFile(ATTACH_BRIDGE_REGISTRY_PATH, "utf8");
-		const parsed = JSON.parse(text) as AttachBridgeRegistry;
-		return Array.isArray(parsed.targets) ? parsed.targets : [];
-	} catch {
-		return [];
-	}
-}
-
-async function readBrowserMetadata(browserURL: string) {
-	const normalizedBrowserURL = normalizeBrowserURL(browserURL);
-	const response = await fetch(`${normalizedBrowserURL}/json/version`, {
-		method: "GET",
-		signal: AbortSignal.timeout(3000),
-	});
-	if (!response.ok) {
-		throw new Error(
-			`attach could not read browser metadata from ${normalizedBrowserURL}`,
-		);
-	}
-	return {
-		browserURL: normalizedBrowserURL,
-		json: (await response.json()) as { webSocketDebuggerUrl?: string },
-	};
-}
-
-async function resolveBrowserWsEndpoint(browserURL: string) {
-	const { browserURL: normalizedBrowserURL, json } =
-		await readBrowserMetadata(browserURL);
-	const cdpWebSocketDebuggerUrl = json.webSocketDebuggerUrl?.trim();
-	const normalizedCdpWebSocketDebuggerUrl = cdpWebSocketDebuggerUrl
-		? normalizeAttachMetadataEndpoint(cdpWebSocketDebuggerUrl)
-		: undefined;
-	const cdpPort = parseBrowserPort(normalizedBrowserURL);
-	if (!normalizedCdpWebSocketDebuggerUrl) {
-		throw new Error(
-			`attach did not receive webSocketDebuggerUrl from ${normalizedBrowserURL}/json/version`,
-		);
-	}
-	const registry = await readAttachBridgeRegistry();
-	const registryMatch = registry.find((target) => {
-		const browserURLMatches = target.browserURL === normalizedBrowserURL;
-		const cdpPortMatches =
-			cdpPort !== undefined &&
-			Number.isInteger(target.cdpPort) &&
-			target.cdpPort === cdpPort;
-		if (!browserURLMatches && !cdpPortMatches) return false;
-		if (!target.wsEndpoint?.trim()) return false;
-		return !(
-			target.cdpWebSocketDebuggerUrl?.trim() &&
-			normalizeAttachMetadataEndpoint(target.cdpWebSocketDebuggerUrl.trim()) !==
-				normalizedCdpWebSocketDebuggerUrl
-		);
-	});
-	const wsEndpoint = registryMatch?.wsEndpoint?.trim();
-	if (!wsEndpoint) {
-		throw new Error(
-			`ATTACH_SUBSTRATE_UNAVAILABLE: ${normalizedBrowserURL} exposes CDP metadata but no Playwright ws bridge. Start a cooperating target such as \`node test/fixtures/targets/attach-target.js\`, or attach with \`--ws-endpoint\`.`,
-		);
-	}
-	return wsEndpoint;
+	return "endpoint";
 }
 
 export async function resolveAttachTarget(
 	endpoint: string | undefined,
-	options: { wsEndpoint?: string; browserUrl?: string; cdp?: string },
+	options: {
+		wsEndpoint?: string;
+		browserUrl?: string;
+		cdp?: string;
+	},
 ): Promise<ResolvedAttachTarget> {
 	const candidates = [
 		options.wsEndpoint
@@ -408,45 +339,63 @@ export async function resolveAttachTarget(
 		options.browserUrl
 			? { endpoint: options.browserUrl, resolvedVia: "browser-url" as const }
 			: null,
-		options.cdp
-			? {
-					endpoint: `http://127.0.0.1:${options.cdp}`,
-					resolvedVia: "cdp" as const,
-				}
-			: null,
+		options.cdp ? { endpoint: options.cdp, resolvedVia: "cdp" as const } : null,
 		endpoint ? { endpoint, resolvedVia: "argument" as const } : null,
 	].filter(Boolean) as RawAttachTarget[];
 	if (candidates.length === 0) {
 		throw new Error(
-			"attach requires an endpoint, --ws-endpoint <url>, --browser-url <url>, or --cdp <port>",
+			"attach requires an endpoint, --ws-endpoint <url>, --browser-url <url>, or --cdp <port-or-url>",
 		);
 	}
 	if (candidates.length > 1)
 		throw new Error("attach accepts exactly one target source");
 	const target = candidates[0];
 	if (target.resolvedVia === "browser-url" || target.resolvedVia === "cdp") {
-		const wsEndpoint = await resolveBrowserWsEndpoint(target.endpoint);
+		const cdpEndpoint = normalizeCdpEndpoint(target.endpoint);
 		return {
-			endpoint: wsEndpoint,
+			endpoint: cdpEndpoint,
 			resolvedVia: target.resolvedVia,
-			browserURL: normalizeBrowserURL(target.endpoint),
+			connectVia: "cdp",
+			browserURL:
+				target.resolvedVia === "browser-url" ? cdpEndpoint : undefined,
+			cdpEndpoint,
 		};
 	}
-	return target;
+	if (target.resolvedVia === "argument") {
+		const connectVia = classifyArgumentEndpoint(target.endpoint);
+		if (connectVia === "cdp") {
+			const cdpEndpoint = normalizeCdpEndpoint(target.endpoint);
+			return {
+				endpoint: cdpEndpoint,
+				resolvedVia: target.resolvedVia,
+				connectVia,
+				cdpEndpoint,
+			};
+		}
+	}
+	return {
+		endpoint: normalizeURL(target.endpoint),
+		resolvedVia: target.resolvedVia,
+		connectVia: "endpoint",
+	};
 }
 
 export async function attachManagedSession(options: {
 	sessionName: string;
 	endpoint: string;
 	resolvedVia: string;
+	connectVia?: "endpoint" | "cdp";
 	browserURL?: string;
+	cdpEndpoint?: string;
 }) {
 	const probe = await runManagedSessionCommand(
 		{ _: ["snapshot"] },
 		{
 			sessionName: options.sessionName,
 			reset: true,
-			endpoint: options.endpoint,
+			...(options.connectVia === "cdp" && options.cdpEndpoint
+				? { cdp: options.cdpEndpoint }
+				: { endpoint: options.endpoint }),
 			createIfMissing: true,
 		},
 	);
@@ -462,7 +411,9 @@ export async function attachManagedSession(options: {
 			attached: true,
 			endpoint: options.endpoint,
 			resolvedVia: options.resolvedVia,
+			connectVia: options.connectVia ?? "endpoint",
 			...(options.browserURL ? { browserURL: options.browserURL } : {}),
+			...(options.cdpEndpoint ? { cdpEndpoint: options.cdpEndpoint } : {}),
 			currentPageAvailable: Boolean(page),
 		},
 	};

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -129,6 +129,7 @@ type EnsureManagedSessionOptions = {
 	profile?: string;
 	persistent?: boolean;
 	endpoint?: string;
+	cdp?: string;
 	createIfMissing?: boolean;
 	config?: string;
 };
@@ -691,6 +692,7 @@ async function ensureManagedSessionUnlocked(
 									...(options?.profile ? { profile: options.profile } : {}),
 									...(options?.persistent ? { persistent: true } : {}),
 									...(options?.endpoint ? { endpoint: options.endpoint } : {}),
+									...(options?.cdp ? { cdp: options.cdp } : {}),
 									...(options?.config ? { config: options.config } : {}),
 								}),
 							),

--- a/src/engine/shared.ts
+++ b/src/engine/shared.ts
@@ -52,13 +52,17 @@ function canParseRunCodeExpression(source: string) {
 	}
 }
 
+function stripTrailingSemicolons(source: string) {
+	return source.trim().replace(/;+$/, "").trimEnd();
+}
+
 export function normalizeRunCodeSource(source: string) {
-	const trimmed = source.trim();
-	if (!trimmed || looksLikeRunCodeFunction(trimmed)) return source;
-	if (canParseRunCodeExpression(trimmed)) {
-		return `async (page) => (${trimmed})`;
+	const stripped = stripTrailingSemicolons(source);
+	if (!stripped || looksLikeRunCodeFunction(stripped)) return stripped;
+	if (canParseRunCodeExpression(stripped)) {
+		return `async (page) => (${stripped})`;
 	}
-	return `async (page) => {\n${source}\n}`;
+	return `async (page) => {\n${stripped}\n}`;
 }
 
 export function isModalStateBlockedMessage(message: string) {

--- a/src/engine/shared.ts
+++ b/src/engine/shared.ts
@@ -31,6 +31,36 @@ export function normalizeRef(ref: string) {
 	return ref.startsWith("@") ? ref.slice(1) : ref;
 }
 
+function looksLikeRunCodeFunction(source: string) {
+	const trimmed = source.trim();
+	return (
+		/^async\s+function\b/.test(trimmed) ||
+		/^function\b/.test(trimmed) ||
+		/^async\s*\([^)]*\)\s*=>/.test(trimmed) ||
+		/^\([^)]*\)\s*=>/.test(trimmed) ||
+		/^async\s+[A-Za-z_$][\w$]*\s*=>/.test(trimmed) ||
+		/^[A-Za-z_$][\w$]*\s*=>/.test(trimmed)
+	);
+}
+
+function canParseRunCodeExpression(source: string) {
+	try {
+		new Function(`return (async (page) => (${source}));`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function normalizeRunCodeSource(source: string) {
+	const trimmed = source.trim();
+	if (!trimmed || looksLikeRunCodeFunction(trimmed)) return source;
+	if (canParseRunCodeExpression(trimmed)) {
+		return `async (page) => (${trimmed})`;
+	}
+	return `async (page) => {\n${source}\n}`;
+}
+
 export function isModalStateBlockedMessage(message: string) {
 	return (
 		message === "MODAL_STATE_BLOCKED" ||
@@ -61,7 +91,7 @@ export async function managedRunCode(options: {
 		source = await readFile(filename, "utf8");
 	}
 	if (source) {
-		args.push(source);
+		args.push(normalizeRunCodeSource(source));
 	}
 	const attempts = Math.max(1, Math.floor(Number(options.retry ?? 0)) + 1);
 	let result: Awaited<ReturnType<typeof runManagedSessionCommand>> | undefined;

--- a/test/unit/run-code-source.test.ts
+++ b/test/unit/run-code-source.test.ts
@@ -8,6 +8,10 @@ test("normalizeRunCodeSource preserves function expressions", () => {
 		"async (page) => await page.title()",
 	);
 	assert.equal(
+		normalizeRunCodeSource("async (page) => await page.title();"),
+		"async (page) => await page.title()",
+	);
+	assert.equal(
 		normalizeRunCodeSource("page => page.url()"),
 		"page => page.url()",
 	);
@@ -25,5 +29,9 @@ test("normalizeRunCodeSource wraps expressions with implicit return", () => {
 		normalizeRunCodeSource("await page.title()"),
 		"async (page) => (await page.title())",
 	);
-	assert.equal(normalizeRunCodeSource("1 + 1"), "async (page) => (1 + 1)");
+	assert.equal(
+		normalizeRunCodeSource("await page.title();"),
+		"async (page) => (await page.title())",
+	);
+	assert.equal(normalizeRunCodeSource("1 + 1;"), "async (page) => (1 + 1)");
 });

--- a/test/unit/run-code-source.test.ts
+++ b/test/unit/run-code-source.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeRunCodeSource } from "../../src/engine/shared.js";
+
+test("normalizeRunCodeSource preserves function expressions", () => {
+	assert.equal(
+		normalizeRunCodeSource("async (page) => await page.title()"),
+		"async (page) => await page.title()",
+	);
+	assert.equal(
+		normalizeRunCodeSource("page => page.url()"),
+		"page => page.url()",
+	);
+});
+
+test("normalizeRunCodeSource wraps statement bodies", () => {
+	assert.equal(
+		normalizeRunCodeSource("return await page.title()"),
+		"async (page) => {\nreturn await page.title()\n}",
+	);
+});
+
+test("normalizeRunCodeSource wraps expressions with implicit return", () => {
+	assert.equal(
+		normalizeRunCodeSource("await page.title()"),
+		"async (page) => (await page.title())",
+	);
+	assert.equal(normalizeRunCodeSource("1 + 1"), "async (page) => (1 + 1)");
+});

--- a/test/unit/session-attach-target.test.ts
+++ b/test/unit/session-attach-target.test.ts
@@ -28,6 +28,20 @@ test("resolveAttachTarget maps --cdp http URL to raw CDP endpoint", async () => 
 	});
 });
 
+test("resolveAttachTarget maps --cdp host:port to raw CDP endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, {
+		cdp: "localhost:9333",
+	});
+
+	assert.deepEqual(target, {
+		endpoint: "http://127.0.0.1:9333",
+		resolvedVia: "cdp",
+		connectVia: "cdp",
+		browserURL: undefined,
+		cdpEndpoint: "http://127.0.0.1:9333",
+	});
+});
+
 test("resolveAttachTarget maps --cdp websocket URL to raw CDP endpoint", async () => {
 	const target = await resolveAttachTarget(undefined, {
 		cdp: "ws://localhost:9333/devtools/browser/abc",

--- a/test/unit/session-attach-target.test.ts
+++ b/test/unit/session-attach-target.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveAttachTarget } from "../../src/cli/parsers/session.js";
+
+test("resolveAttachTarget maps --cdp port to raw CDP endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, { cdp: "9333" });
+
+	assert.deepEqual(target, {
+		endpoint: "http://127.0.0.1:9333",
+		resolvedVia: "cdp",
+		connectVia: "cdp",
+		browserURL: undefined,
+		cdpEndpoint: "http://127.0.0.1:9333",
+	});
+});
+
+test("resolveAttachTarget maps --cdp http URL to raw CDP endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, {
+		cdp: "http://localhost:9333/",
+	});
+
+	assert.deepEqual(target, {
+		endpoint: "http://127.0.0.1:9333",
+		resolvedVia: "cdp",
+		connectVia: "cdp",
+		browserURL: undefined,
+		cdpEndpoint: "http://127.0.0.1:9333",
+	});
+});
+
+test("resolveAttachTarget maps --cdp websocket URL to raw CDP endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, {
+		cdp: "ws://localhost:9333/devtools/browser/abc",
+	});
+
+	assert.deepEqual(target, {
+		endpoint: "ws://127.0.0.1:9333/devtools/browser/abc",
+		resolvedVia: "cdp",
+		connectVia: "cdp",
+		browserURL: undefined,
+		cdpEndpoint: "ws://127.0.0.1:9333/devtools/browser/abc",
+	});
+});
+
+test("resolveAttachTarget maps --browser-url to raw CDP endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, {
+		browserUrl: "http://localhost:9333/",
+	});
+
+	assert.deepEqual(target, {
+		endpoint: "http://127.0.0.1:9333",
+		resolvedVia: "browser-url",
+		connectVia: "cdp",
+		browserURL: "http://127.0.0.1:9333",
+		cdpEndpoint: "http://127.0.0.1:9333",
+	});
+});
+
+test("resolveAttachTarget preserves --ws-endpoint as Playwright endpoint", async () => {
+	const target = await resolveAttachTarget(undefined, {
+		wsEndpoint: "ws://127.0.0.1:1234/playwright",
+	});
+
+	assert.deepEqual(target, {
+		endpoint: "ws://127.0.0.1:1234/playwright",
+		resolvedVia: "ws-endpoint",
+		connectVia: "endpoint",
+	});
+});
+
+test("resolveAttachTarget auto-detects positional HTTP as CDP", async () => {
+	const target = await resolveAttachTarget("http://localhost:9333", {});
+
+	assert.deepEqual(target, {
+		endpoint: "http://127.0.0.1:9333",
+		resolvedVia: "argument",
+		connectVia: "cdp",
+		cdpEndpoint: "http://127.0.0.1:9333",
+	});
+});
+
+test("resolveAttachTarget auto-detects positional devtools websocket as CDP", async () => {
+	const target = await resolveAttachTarget(
+		"ws://localhost:9333/devtools/browser/abc",
+		{},
+	);
+
+	assert.deepEqual(target, {
+		endpoint: "ws://127.0.0.1:9333/devtools/browser/abc",
+		resolvedVia: "argument",
+		connectVia: "cdp",
+		cdpEndpoint: "ws://127.0.0.1:9333/devtools/browser/abc",
+	});
+});
+
+test("resolveAttachTarget keeps positional non-devtools websocket as Playwright endpoint", async () => {
+	const target = await resolveAttachTarget(
+		"ws://localhost:3333/playwright",
+		{},
+	);
+
+	assert.deepEqual(target, {
+		endpoint: "ws://127.0.0.1:3333/playwright",
+		resolvedVia: "argument",
+		connectVia: "endpoint",
+	});
+});


### PR DESCRIPTION
## What changed

- Route `--cdp`, `--browser-url`, positional HTTP endpoints, and positional `/devtools/` websockets through Chromium CDP attach.
- Keep non-devtools websocket endpoints on the Playwright endpoint path.
- Normalize `pw code` snippets so body, expression, and function forms all work.
- Add unit coverage for attach target resolution and run-code source normalization.
- Update README and pwcli skill docs with desktop/Electron attach usage.

## Why

Electron desktop debugging exposes Chromium CDP, not a Playwright ws bridge. Desktop smoke also needs `pw code` to inspect preload state such as `window.agentOne`.

## Validation

- `pnpm build`
- `pnpm test:unit`
- `pnpm lint`
- Manual Electron smoke against CDP 9222:
  - attach/status/snapshot
  - console/errors
  - `pw code` preload probe for `window.agentOne`
